### PR TITLE
Add rednote-hilab/dots.mocr (sglang DP=4 TP=1 on 1 node)

### DIFF
--- a/examples/clariden/cli/rednote-hilab/dots.mocr-sglang.sh
+++ b/examples/clariden/cli/rednote-hilab/dots.mocr-sglang.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Launch rednote-hilab/dots.mocr (1.5B multilingual document-OCR VLM) on
+# one Clariden GH200 node with SGLang, DP=4 TP=1 (4 independent replicas,
+# one per GPU). Suitable for high-throughput batch OCR over many images.
+#
+# dots.mocr requires --trust-remote-code (custom DotsOCRForCausalLM
+# architecture). SGLang ≥ 0.5.x has the model class registered.
+#
+# Model weights (downloaded separately):
+#   /capstor/store/cscs/swissai/infra01/MLLM/OCR/rednote-hilab_dots.mocr/
+#
+sml advanced \
+  --firecrest-system clariden \
+  --partition normal \
+  --slurm-nodes 1 \
+  --slurm-time 6:00:00 \
+  --serving-framework sglang \
+  --worker-port 8080 \
+  --slurm-environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
+  --framework-args "--model-path /capstor/store/cscs/swissai/infra01/MLLM/OCR/rednote-hilab_dots.mocr \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --served-model-name dots_mocr-$(whoami) \
+    --dp-size 4 \
+    --tp-size 1 \
+    --trust-remote-code \
+    --context-length 16384 \
+    --mem-fraction-static 0.85"

--- a/src/swiss_ai_model_launch/assets/models.json
+++ b/src/swiss_ai_model_launch/assets/models.json
@@ -138,5 +138,12 @@
     "environment": null,
     "nodes_per_worker": 4,
     "framework_args": "--tp-size 16 --reasoning-parser glm45 --tool-call-parser glm47 --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --mem-fraction-static 0.85"
+  },
+  {
+    "model": "rednote-hilab/dots.mocr",
+    "framework": "sglang",
+    "environment": null,
+    "nodes_per_worker": 1,
+    "framework_args": "--dp-size 4 --tp-size 1 --trust-remote-code --context-length 16384 --mem-fraction-static 0.85"
   }
 ]


### PR DESCRIPTION
## Summary

- Register `rednote-hilab/dots.mocr` (1.5B multilingual document-OCR VLM) in `models.json` for sglang serving on a single GH200 node, **DP=4 TP=1** (4 independent replicas, one per GPU). Suitable for high-throughput batch OCR over many images.
- Add matching CLI example at `examples/clariden/cli/rednote-hilab/dots.mocr-sglang.sh` using `sml advanced`.
- Served-model-name set to `dots_mocr-$(whoami)` for short, user-namespaced API ids.

## Why

dots.mocr (rebranded from `dots.ocr-1.5` in March 2026) is currently SOTA-on-average among open-weights document OCR models. Strong benchmarks: olmOCR-Bench 1104.4, OmniDocBench v1.5 1059.0, XDocParse 1210.7. 1.5B params + 100-language coverage + structured-graphics-to-SVG conversion make it a good general OCR primary model. Limitations: weak on cursive handwriting (use a TrOCR/DTrOCR specialist as a second pass for that).

## Notes

- Custom architecture `DotsOCRForCausalLM` requires `--trust-remote-code`. Confirmed registered in vLLM/SGLang upstream as of vLLM 0.11.0+ and SGLang 0.5.x.
- Model weights are expected at `/capstor/store/cscs/swissai/infra01/MLLM/OCR/rednote-hilab_dots.mocr/`. Download with: `huggingface-cli download rednote-hilab/dots.mocr`.
- This branch is based on `main` and does **not** include the template.jinja `SLURM_SPANK_*pyxis_*` unset fix from the in-flight Qwen3.6-27B PR. When launching from a nested pyxis shell, callers must currently `unset SLURM_SPANK__SLURM_SPANK_OPTION_pyxis_environment SLURM_SPANK__SLURM_SPANK_OPTION_pyxis_container_mounts SLURM_SPANK__SLURM_SPANK_OPTION_pyxis_container_writable` before invoking sml. Once that PR lands the issue resolves automatically.

## Test plan

- [x] JSON parses cleanly: `python -c "import json; json.load(open('src/swiss_ai_model_launch/assets/models.json'))"`
- [x] Shell syntax check: `bash -n examples/clariden/cli/rednote-hilab/dots.mocr-sglang.sh`
- [x] End-to-end SLURM launch on Clariden via `bash examples/clariden/cli/rednote-hilab/dots.mocr-sglang.sh` (with `--slurm-reservation` override + manual env unset). Job came up in <2 min, model loaded in <1 min, all 4 DP replicas captured CUDA graphs successfully.
- [x] Server health: `GET /v1/models` returns `dots_mocr-xyixuan`. `POST /v1/chat/completions` with image input works.
- [x] Throughput verified: ~6.7 req/s aggregate on 16-concurrent OCR-batch traffic, mean 0.78s, p95 1.89s per request.
- [x] OCR quality verified on 100 random Smithsonian-museum images: 0 errors, 47% NO_TEXT (correctly identified text-free images), 53% substantive transcription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)