### PR TITLE
Add suggested launch config for gpt oss-20b and 120b

### DIFF
--- a/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
+++ b/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
@@ -6,9 +6,9 @@ sml advanced \
   --serving-framework sglang \
   --worker-port 8080 \
   --slurm-environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
-  --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/openai/gpt-oss-20b \
+  --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/openai/gpt-oss-120b \
     --host 0.0.0.0 \
     --port 8080 \
-    --served-model-name openai/gpt-oss-20b-$(whoami) \
+    --served-model-name openai/gpt-oss-120b-$(whoami) \
     --dp-size 4 \
     --enable-metrics"

--- a/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
+++ b/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
@@ -2,7 +2,7 @@
 sml advanced \
   --firecrest-system clariden \
   --partition normal \
-  --slurm-nodes 2 \
+  --slurm-nodes 1 \
   --serving-framework sglang \
   --worker-port 8080 \
   --slurm-environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
@@ -10,5 +10,6 @@ sml advanced \
     --host 0.0.0.0 \
     --port 8080 \
     --served-model-name openai/gpt-oss-120b-$(whoami) \
-    --tp-size 8 \
+    --tp-size 4 \
+    --ep-size 4 \
     --enable-metrics"

--- a/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
+++ b/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
@@ -10,5 +10,5 @@ sml advanced \
     --host 0.0.0.0 \
     --port 8080 \
     --served-model-name openai/gpt-oss-120b-$(whoami) \
-    --dp-size 4 \
+    --tp-size 4 \
     --enable-metrics"

--- a/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
+++ b/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+sml advanced \
+  --firecrest-system clariden \
+  --partition normal \
+  --slurm-nodes 1 \
+  --serving-framework sglang \
+  --worker-port 8080 \
+  --slurm-environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
+  --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/openai/gpt-oss-20b \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --served-model-name openai/gpt-oss-20b-$(whoami) \
+    --dp-size 4 \
+    --enable-metrics"

--- a/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
+++ b/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
@@ -2,7 +2,7 @@
 sml advanced \
   --firecrest-system clariden \
   --partition normal \
-  --slurm-nodes 1 \
+  --slurm-nodes 2 \
   --serving-framework sglang \
   --worker-port 8080 \
   --slurm-environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
@@ -10,5 +10,5 @@ sml advanced \
     --host 0.0.0.0 \
     --port 8080 \
     --served-model-name openai/gpt-oss-120b-$(whoami) \
-    --tp-size 4 \
+    --tp-size 8 \
     --enable-metrics"

--- a/examples/clariden/cli/openai/gpt-oss-20b-sglang.sh
+++ b/examples/clariden/cli/openai/gpt-oss-20b-sglang.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+sml advanced \
+  --firecrest-system clariden \
+  --partition normal \
+  --slurm-nodes 1 \
+  --serving-framework sglang \
+  --worker-port 8080 \
+  --slurm-environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
+  --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/openai/gpt-oss-20b \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --served-model-name openai/gpt-oss-20b-$(whoami) \
+    --dp-size 4 \
+    --enable-metrics"


### PR DESCRIPTION
## Summary

This PR adds suggested launch scripts for GPT-OSS 20B and GPT-OSS 120B using the existing SGLang launch template.

## Added scripts

- `suggested_gpt_oss_20b_sglang.sh`
- `suggested_gpt_oss_120b_sglang.sh`

## Notes

The scripts follow the existing SGLang-style template and update the model path and served model name for:

- `openai/gpt-oss-20b`
- `openai/gpt-oss-120b`

They assume that the corresponding model weights have already been synced under the shared Hugging Face model cache:

```bash
/capstor/store/cscs/swissai/infra01/hf_models/models/openai/