### PR TITLE
feat: pass launch metadata to OCF via --label flags

### DIFF
--- a/src/swiss_ai_model_launch/assets/template.jinja
+++ b/src/swiss_ai_model_launch/assets/template.jinja
@@ -186,7 +186,19 @@ $FRAMEWORK_LAUNCH --distributed-executor-backend ray $FRAMEWORK_ARGS"
 
         # Wrap with OCF if enabled (only on master node - rank 0)
         if [ "$USE_OCF" = "true" ] && [ $local_rank -eq 0 ]; then
-            FRAMEWORK_CMD="\$OCF_BIN start --bootstrap.addr \"$OCF_BOOTSTRAP_ADDR\" --service.name $OCF_SERVICE_NAME --service.port $OCF_SERVICE_PORT --subprocess \"$FRAMEWORK_CMD\""
+            # Launch-time metadata surfaced via OCF --label flags so the DNT
+            # entry carries owner / scheduling / framework info instead of
+            # forcing consumers to cross-reference SLURM separately.
+            OCF_LABELS="\
+--label launched_by=$USER \
+--label slurm_job_id=$SLURM_JOB_ID \
+--label slurm_partition=${SLURM_JOB_PARTITION:-unknown} \
+--label worker_group_id=$SLURM_JOB_ID \
+--label worker_id=$worker_id \
+--label framework=$FRAMEWORK \
+--label served_model_name=\"$SERVED_MODEL_NAME\" \
+--label started_at=$(date -u +%FT%TZ)"
+            FRAMEWORK_CMD="\$OCF_BIN start --bootstrap.addr \"$OCF_BOOTSTRAP_ADDR\" --service.name $OCF_SERVICE_NAME --service.port $OCF_SERVICE_PORT $OCF_LABELS --subprocess \"$FRAMEWORK_CMD\""
         fi
 
         srun --nodes=1 --ntasks=1 --nodelist=$node \


### PR DESCRIPTION
The DNT entry for each launched model now carries who launched it, which SLURM job/partition it belongs to, the framework, the served model name, and the start time. Consumers (serving-api UI) can show this directly instead of needing to cross-reference SLURM.

worker_group_id is set to the SLURM job id so peers from a multi-node launch can be aggregated as one logical model in the UI; worker_id is the per-replica index for multi-replica launches.

Depends on the matching --label flag in opentela
(swiss-ai/opentela feat/peer-metadata) shipping in a v0.0.6+ binary; older OCF binaries will fail to parse the flag.