### PR TITLE
Add Qwen3-TTS VoiceDesign vLLM-Omni launcher

### DIFF
--- a/examples/clariden/cli/funaudiollm/Fun-CosyVoice3-0.5B-2512-vllm-omni.sh
+++ b/examples/clariden/cli/funaudiollm/Fun-CosyVoice3-0.5B-2512-vllm-omni.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Launch Fun-CosyVoice3 0.5B with vLLM on one Clariden GH200 node.
+#
+# Model: FunAudioLLM/Fun-CosyVoice3-0.5B-2512
+#
+# Note:
+#   CosyVoice3 requires ref_audio/ref_text for /v1/audio/speech.
+#   If using local file:// reference audio, set:
+#     export COSYVOICE_ALLOWED_LOCAL_MEDIA_PATH=/path/to/reference/audio/root
+
+EXTRA_MEDIA_ARGS=""
+
+if [ -n "${COSYVOICE_ALLOWED_LOCAL_MEDIA_PATH:-}" ]; then
+  EXTRA_MEDIA_ARGS="--allowed-local-media-path ${COSYVOICE_ALLOWED_LOCAL_MEDIA_PATH}"
+fi
+
+sml advanced \
+  --firecrest-system clariden \
+  --partition normal \
+  --slurm-nodes 1 \
+  --slurm-time 6:00:00 \
+  --serving-framework vllm \
+  --served-model-name FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
+  --worker-port 8080 \
+  --slurm-environment src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml \
+  --framework-args "FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --deploy-config /opt/conda/lib/python3.12/site-packages/vllm_omni/deploy/cosyvoice3.yaml \
+    --omni \
+    --trust-remote-code \
+    --enforce-eager \
+    --max-model-len 8192 \
+    --gpu-memory-utilization 0.40 \
+    ${EXTRA_MEDIA_ARGS}" \
+  --no-tui

--- a/examples/clariden/cli/qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign-vllm-omni.sh
+++ b/examples/clariden/cli/qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign-vllm-omni.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Launch Qwen3-TTS 12Hz 1.7B VoiceDesign with vLLM on one Clariden GH200 node.
+#
+# Model: Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign
+
+sml advanced \
+  --firecrest-system clariden \
+  --partition normal \
+  --slurm-nodes 1 \
+  --slurm-time 6:00:00 \
+  --serving-framework vllm \
+  --served-model-name Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign \
+  --worker-port 8080 \
+  --slurm-environment src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml \
+  --framework-args "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --deploy-config /opt/conda/lib/python3.12/site-packages/vllm_omni/deploy/qwen3_tts.yaml \
+    --omni \
+    --trust-remote-code \
+    --enforce-eager \
+    --max-model-len 8192 \
+    --gpu-memory-utilization 0.40" \
+  --no-tui

--- a/images/vllm_cuda13_v2/Dockerfile
+++ b/images/vllm_cuda13_v2/Dockerfile
@@ -1,0 +1,86 @@
+ARG UBUNTU_VERSION=24.04
+ARG TARGET_PLATFORM=aarch64
+ARG CUDA_VERSION=13.0.0
+ARG CUDA_VERSION_PATH=cu130
+ARG PYTHON_VERSION=3.12
+ARG BASE_IMAGE=docker.io/library/ubuntu:${UBUNTU_VERSION}
+ARG DEVEL_BASE_IMAGE=docker.io/nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu${UBUNTU_VERSION}
+
+
+FROM ${DEVEL_BASE_IMAGE} AS build
+
+WORKDIR /app/build
+
+# Install miniconda, Python, and Python build dependencies.
+ARG TARGET_PLATFORM
+ARG PYTHON_VERSION
+ENV PATH=/opt/conda/bin:$PATH
+ADD "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${TARGET_PLATFORM}.sh" /root/miniconda.sh
+RUN chmod +x /root/miniconda.sh && \
+    bash /root/miniconda.sh -b -p /opt/conda && \
+    rm /root/miniconda.sh && \
+    /opt/conda/bin/conda install -y python=${PYTHON_VERSION} cmake conda-build pyyaml ipython git compilers make && \
+    /opt/conda/bin/python -m pip install --upgrade --no-cache-dir pip wheel packaging "setuptools<70.0.0" ninja && \
+    /opt/conda/bin/conda clean -ya
+
+# Install vLLM CUDA13 stack compatible with vLLM-Omni 0.20.0.
+# Use --python explicitly so uv targets the conda Python, not /usr Python.
+RUN pip install --no-cache-dir uv==0.11.7 && \
+    uv pip install --python /opt/conda/bin/python --no-cache torch==2.11.0 --torch-backend=auto && \
+    uv pip install --python /opt/conda/bin/python --no-cache vllm==0.20.2 --torch-backend=auto && \
+    rm -rf /root/.cache/uv
+
+# Ensure ray is installed and on PATH.
+RUN /opt/conda/bin/python -m pip install --no-cache-dir "ray[default]==2.55.0"
+
+# Symlink cuDNN and NCCL headers into conda include path.
+RUN CUDNN_DIR=$(dirname "$(find /usr -name 'cudnn.h' -print -quit)") && \
+    ln -sf "${CUDNN_DIR}"/cudnn*.h /opt/conda/include/ && \
+    ln -sf "$(find /opt/conda/lib -path '*/nvidia/nccl/include/nccl.h' -print -quit)" /opt/conda/include/nccl.h
+
+# Remove nvidia-cublas (pulled as transitive dep) — conflicts with CUDA 13 toolkit's cuBLAS.
+RUN /opt/conda/bin/python -m pip uninstall -y nvidia-cublas 2>/dev/null; true
+
+# Install curl for router health checks.
+RUN conda install -y curl && conda clean -ya
+
+# Install audio system dependencies for Qwen3-TTS & vLLM-Omni.
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install runtime dependencies for Qwen3-TTS & vLLM-Omni.
+# vLLM-Omni is installed without dependencies to avoid replacing torch/vLLM/CUDA wheels.
+RUN uv pip install --python /opt/conda/bin/python --no-cache --no-deps \
+    vllm-omni==0.20.0 && \
+    uv pip install --python /opt/conda/bin/python --no-cache \
+    av==16.0.1 \
+    omegaconf==2.3.0 \
+    diffusers==0.36.0 \
+    accelerate==1.12.0 \
+    soundfile==0.13.1 \
+    cache-dit==1.3.0 \
+    tqdm==4.67.1 \
+    torchsde==0.2.6 \
+    openai-whisper==20250625 \
+    "imageio[ffmpeg]==2.37.2" \
+    x-transformers==2.12.2 \
+    einops==0.8.1 \
+    prettytable==3.17.0 \
+    aenum==3.1.16 \
+    pyzmq==27.1.0 \
+    janus==2.0.0 \
+    pydub==0.25.1 \
+    onnxruntime==1.23.2 \
+    fa3-fwd==0.0.3 \
+    transformers==5.8.0 \
+    gradio==6.14.0 \
+    gradio-client==2.5.0 \
+    librosa==0.11.0 \
+    requests==2.34.2 \
+    numpy==2.3.5 && \
+    rm -rf /root/.cache/uv
+
+WORKDIR /opt

--- a/src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml
+++ b/src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml
@@ -1,0 +1,36 @@
+image = "/capstor/store/cscs/swissai/infra01/container-images/ci/vllm_cuda13_v2.sqsh"
+
+mounts = [
+  "/capstor/store/cscs/swissai/infra01/ocf-share:/ocfbin",
+  "/capstor",
+  "/iopsstor",
+  "/usr/lib64/libhwloc.so.15:/usr/lib/libhwloc.so.15",
+  "/usr/lib64/libpciaccess.so.0:/usr/lib/libpciaccess.so.0",
+  "/usr/lib64/libxml2.so.2:/usr/lib/libxml2.so.2",
+  "/usr/lib64/libnuma.so.1:/usr/lib/libnuma.so.1",
+]
+
+workdir = "/opt"
+
+[env]
+NCCL_NET = "AWS Libfabric"
+NCCL_CROSS_NIC = "1"
+NCCL_NET_GDR_LEVEL = "PHB"
+NCCL_SOCKET_IFNAME = "hsn"
+NCCL_PROTO = "^LL128"
+FI_CXI_COMPAT = "0"
+FI_MR_CACHE_MONITOR = "userfaultfd"
+FI_CXI_RX_MATCH_MODE = "software"
+FI_CXI_DEFAULT_CQ_SIZE = "131072"
+FI_CXI_DEFAULT_TX_SIZE = "32768"
+FI_CXI_DISABLE_HOST_REGISTER = "1"
+OFI_NCCL_DISABLE_DMABUF = "1"
+VLLM_ALLREDUCE_USE_SYMM_MEM = "0"
+
+VLLM_USE_DEEP_GEMM = "0"
+TORCHDYNAMO_DISABLE = "1"
+
+[annotations]
+com.hooks.aws_ofi_nccl.enabled = "true"
+com.hooks.aws_ofi_nccl.variant = "cuda13"
+com.hooks.cxi.enabled = "true"

--- a/src/swiss_ai_model_launch/assets/models.json
+++ b/src/swiss_ai_model_launch/assets/models.json
@@ -202,5 +202,19 @@
     "environment": null,
     "nodes_per_replica": 1,
     "framework_args": "--tp-size 4 --reasoning-parser deepseek-r1 --enable-metrics"
+  },
+  {
+    "model": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+    "framework": "vllm",
+    "environment": "src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml",
+    "nodes_per_worker": 1,
+    "framework_args": "--deploy-config /opt/conda/lib/python3.12/site-packages/vllm_omni/deploy/qwen3_tts.yaml --omni --trust-remote-code --enforce-eager --max-model-len 8192 --gpu-memory-utilization 0.40"
+  },
+  {
+    "model": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
+    "framework": "vllm",
+    "environment": "src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml",
+    "nodes_per_worker": 1,
+    "framework_args": "--deploy-config /opt/conda/lib/python3.12/site-packages/vllm_omni/deploy/cosyvoice3.yaml --omni --trust-remote-code --enforce-eager --max-model-len 8192 --gpu-memory-utilization 0.40"
   }
 ]

--- a/src/swiss_ai_model_launch/launchers/framework.py
+++ b/src/swiss_ai_model_launch/launchers/framework.py
@@ -60,7 +60,7 @@ class Sglang(Framework):
 
 class Vllm(Framework):
     name = "vllm"
-    entrypoint = "python3 -m vllm.entrypoints.openai.api_server"
+    entrypoint = "vllm serve"
     env_exports = [
         "export RAY_CGRAPH_get_timeout=1800",
         'export no_proxy="0.0.0.0,$no_proxy"',


### PR DESCRIPTION
Adds `examples/clariden/cli/qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign-vllm-omni.sh`, single-node launcher for [`Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign`](https://github.com/QwenLM/Qwen3-TTS), serving text-to-speech via vLLM-Omni on Clariden GH200.

Adds `images/vllm_qwen3_tts_cuda13/Dockerfile` and `src/swiss_ai_model_launch/assets/envs/vllm_qwen3_tts_cuda13.toml`, a CUDA13 vLLM-Omni TTS environment with `vllm==0.20.2`, `vllm-omni==0.20.0`, `transformers==5.8.0`, and audio dependencies such as FFmpeg, libsndfile, and soundfile.

Adds `Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign` to `src/swiss_ai_model_launch/assets/models.json`, an interactive SML catalog entry using vLLM-Omni with `--max-model-len 8192` and `--gpu-memory-utilization 0.40`. VoiceDesign was tested with `task_type=VoiceDesign` and text instructions rather than preset CustomVoice speakers.

Also adds `vllm-omni` as a supported framework where required, matching the existing vLLM-Omni serving pattern.

Validated from a clean checkout:
- `sml advanced` launch works
- interactive `sml` catalog launch works