### PR TITLE
Hardcode telemetry endpoint and improve init UX

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -59,7 +59,7 @@ Set `SML_DEBUG=1` to include local variables in crash tracebacks:
 export SML_DEBUG=1
 ```
 
-> **Warning:** `SML_DEBUG=1` may expose secrets (CSCS API key, FirecREST credentials) in crash output. Don't share terminal output captured with this flag.
+> **Warning:** `SML_DEBUG=1` may expose secrets (CSCS Serving API Key, FirecREST credentials) in crash output. Don't share terminal output captured with this flag.
 
 By default, locals are stripped from crash reports.
 

--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -32,15 +32,14 @@ If you're not sure, start with `firecrest` — it's what most users run.
 | `--firecrest-token-uri` |                               | FirecREST token URI (default: CSCS auth endpoint)              |
 |                         | `SML_FIRECREST_CLIENT_ID`     | FirecREST client ID                                            |
 |                         | `SML_FIRECREST_CLIENT_SECRET` | FirecREST client secret                                        |
-|                         | `SML_CSCS_API_KEY`            | CSCS API key (used for health checks against the served model) |
-| `--telemetry-endpoint`  |                               | Endpoint for telemetry reports                                 |
+|                         | `SML_CSCS_API_KEY`            | CSCS Serving API Key (used for health checks of served model)  |
 
 The FirecREST fields are only required when `--launcher firecrest`. `SML_CSCS_API_KEY` is required regardless of launcher.
 
 ## Where credentials come from
 
 - **FirecREST client ID / secret** — Acquire from the [CSCS Developer Portal](https://developer.svc.cscs.ch/devportal/apis). See the [FirecREST docs](https://docs.cscs.ch/services/devportal/#manage-your-applications) for the full walkthrough.
-- **CSCS API key** — Log in at [serving.swissai.svc.cscs.ch](https://serving.swissai.svc.cscs.ch/) with your institutional account, then go to **View API Keys**.
+- **CSCS Serving API Key** — Log in at [serving.swissai.svc.cscs.ch](https://serving.swissai.svc.cscs.ch/) with your institutional account, then go to **View API Keys**.
 
 ## Config file shape
 
@@ -53,7 +52,6 @@ firecrest_token_uri: https://auth.cscs.ch/...
 firecrest_client_id: <secret>
 firecrest_client_secret: <secret>
 cscs_api_key: <secret>
-telemetry_endpoint: https://...
 ```
 
 Treat this file as a secret. Don't commit it.

--- a/src/swiss_ai_model_launch/cli/configuration/init_wizard.py
+++ b/src/swiss_ai_model_launch/cli/configuration/init_wizard.py
@@ -33,12 +33,11 @@ class InitConfig(ChainConfiguration):
                         options={
                             "firecrest": (
                                 "FirecREST",
-                                "If you have FirecREST credentials of the cluster.",
+                                "5-10min setup instructions at https://docs.cscs.ch/services/devportal/#getting-started",
                             ),
                             "slurm": (
                                 "SLURM Commands",
-                                "If you are running the CLI on the cluster head node "
-                                "and want to directly submit jobs using SLURM.",
+                                "Assumes you are already SSH'd into the cluster.",
                             ),
                         },
                     ),
@@ -59,6 +58,12 @@ class InitConfig(ChainConfiguration):
                                 PasswordConfiguration(
                                     name="firecrest_client_id",
                                     prompt="What is your FirecREST client ID?",
+                                    intro=(
+                                        "\nFirecREST client ID & secret come from your CSCS Developer Portal app.\n"
+                                        "Get them at: https://developer.svc.cscs.ch/devportal/apis\n"
+                                        "(See https://docs.cscs.ch/services/devportal/#manage-your-applications "
+                                        "for the walkthrough)\n"
+                                    ),
                                     env_var="SML_FIRECREST_CLIENT_ID",
                                     expose_as_arg=False,
                                 ),
@@ -75,14 +80,13 @@ class InitConfig(ChainConfiguration):
                 ),
                 PasswordConfiguration(
                     name="cscs_api_key",
-                    prompt="What is your CSCS API key? (https://serving.swissai.svc.cscs.ch)",
+                    prompt="What is your CSCS Serving API Key?",
+                    intro=(
+                        "\nThe CSCS Serving API Key is used for health checks against your served model.\n"
+                        "Get one at: https://serving.swissai.svc.cscs.ch  (log in -> View API Keys)\n"
+                    ),
                     env_var="SML_CSCS_API_KEY",
                     expose_as_arg=False,
-                ),
-                TextConfiguration(
-                    name="telemetry_endpoint",
-                    prompt="Where to send telemetry reports?",
-                    default="https://sml-dev.swissai.svc.cscs.ch/launches",
                 ),
             ],
         )

--- a/src/swiss_ai_model_launch/cli/configuration/models.py
+++ b/src/swiss_ai_model_launch/cli/configuration/models.py
@@ -49,6 +49,7 @@ class _Configuration(BaseModel):
 class _ResolvableConfiguration(_Configuration):
     value: str | None = None
     prompt: str | None = Field(default=None, exclude=True)
+    intro: str | None = Field(default=None, exclude=True)
     env_var: str | None = Field(default=None, exclude=True)
     expose_as_arg: bool = Field(default=True, exclude=True)
 
@@ -57,6 +58,10 @@ class _ResolvableConfiguration(_Configuration):
 
     def _on_answer(self) -> None:
         pass
+
+    def _print_intro(self) -> None:
+        if self.intro:
+            print(self.intro)
 
     def _try_resolve_without_prompt(self, args: argparse.Namespace | None) -> str | None:
         if self.expose_as_arg and args is not None:
@@ -88,6 +93,7 @@ class _ResolvableConfiguration(_Configuration):
             return
         if non_interactive:
             raise ValueError(self._missing_value_message())
+        self._print_intro()
         self.value = await self._get_question().ask_async()
         self._on_answer()
 
@@ -167,6 +173,7 @@ class TextConfiguration(_ResolvableConfiguration):
             return
         if non_interactive:
             raise ValueError(self._missing_value_message())
+        self._print_intro()
         self.value = await questionary.text(
             self.prompt or self.name,
             default=await self._resolve_default(get_value) or "",
@@ -286,6 +293,7 @@ class OptionsConfiguration(_ResolvableConfiguration):
         if len(options) == 1:
             self.value = next(iter(options))
         else:
+            self._print_intro()
             self.value = await self._build_question(options).ask_async()
         self._on_answer()
 

--- a/src/swiss_ai_model_launch/cli/main.py
+++ b/src/swiss_ai_model_launch/cli/main.py
@@ -26,7 +26,7 @@ from swiss_ai_model_launch.cli.healthcheck import check_model_health
 from swiss_ai_model_launch.cli.healthcheck.model_health import ModelHealth
 from swiss_ai_model_launch.launchers import FirecRESTLauncher, Launcher, SlurmLauncher
 from swiss_ai_model_launch.launchers.framework import OCF_BOOTSTRAP_ADDR_DEV, render_master, render_rank_scripts
-from swiss_ai_model_launch.launchers.launch_args import LaunchArgs
+from swiss_ai_model_launch.launchers.launch_args import TELEMETRY_ENDPOINT, LaunchArgs
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
 from swiss_ai_model_launch.launchers.topology import Topology
@@ -466,7 +466,6 @@ async def _create_launcher(
     non_interactive: bool = False,
 ) -> Launcher:
     launcher_type = config.get_non_none_value("launcher")
-    telemetry_endpoint = config.get_value("telemetry_endpoint")
 
     if launcher_type == "slurm" and getattr(args, "firecrest_system", None):
         _logger.warning("--firecrest-system is ignored when using the SLURM launcher")
@@ -477,7 +476,7 @@ async def _create_launcher(
             Launcher,
             await _get_firecrest_launcher_with_client(
                 firecrest_client,
-                telemetry_endpoint=telemetry_endpoint,
+                telemetry_endpoint=TELEMETRY_ENDPOINT,
                 args=args,
                 non_interactive=non_interactive,
             ),
@@ -486,7 +485,7 @@ async def _create_launcher(
         return cast(
             Launcher,
             await _get_slurm_launcher(
-                telemetry_endpoint=telemetry_endpoint,
+                telemetry_endpoint=TELEMETRY_ENDPOINT,
                 args=args,
                 non_interactive=non_interactive,
             ),
@@ -549,6 +548,7 @@ async def _run_preconfigured(args: argparse.Namespace) -> None:
         print(f"Job submitted: {job_id}")
         print(f"Served model name: {served}")
         print(f"Logs: {launcher.get_log_dir(job_id)}")
+        print(f"Tail: {launcher.get_tail_hint(job_id)}")
 
 
 def build_launch_args_from_advanced(
@@ -627,7 +627,7 @@ async def _run_advanced(args: argparse.Namespace) -> None:
         args,
         account=launcher.account,
         partition=launcher.partition,
-        telemetry_endpoint=config.get_value("telemetry_endpoint"),
+        telemetry_endpoint=TELEMETRY_ENDPOINT,
     )
 
     if args.output_script:
@@ -662,6 +662,7 @@ async def _run_advanced(args: argparse.Namespace) -> None:
         print(f"Job submitted: {job_id}")
         print(f"Served model name: {served}")
         print(f"Logs: {launcher.get_log_dir(job_id)}")
+        print(f"Tail: {launcher.get_tail_hint(job_id)}")
 
 
 def _run_mcp() -> None:

--- a/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
@@ -239,8 +239,8 @@ class FirecRESTLauncher(Launcher):
 
             return out_log, err_log
 
-    def get_log_dir(self, job_id: int) -> str:
-        return str(Path(self._get_working_dir()) / "logs" / str(job_id))
+    def get_tail_hint(self, job_id: int) -> str:
+        return f"ssh <host> tail -f ~/.sml/logs/{job_id}/log.out\n  (replace <host> with your cluster SSH alias)"
 
     async def cancel_job(self, job_id: int) -> None:
         try:

--- a/src/swiss_ai_model_launch/launchers/launch_args.py
+++ b/src/swiss_ai_model_launch/launchers/launch_args.py
@@ -11,6 +11,8 @@ from swiss_ai_model_launch.launchers.topology import Topology
 # it as a knob just creates ways for the three to drift.
 FRAMEWORK_PORT = 8080
 
+TELEMETRY_ENDPOINT = "https://sml-dev.swissai.svc.cscs.ch/launches"
+
 _PORT_FLAG_RE = re.compile(r"(?:^|\s)--port(?:[\s=])")
 
 

--- a/src/swiss_ai_model_launch/launchers/launcher.py
+++ b/src/swiss_ai_model_launch/launchers/launcher.py
@@ -41,5 +41,8 @@ class Launcher(ABC):
     @abstractmethod
     async def cancel_job(self, job_id: int) -> None: ...
 
+    def get_log_dir(self, job_id: int) -> str:
+        return f"~/.sml/logs/{job_id}"
+
     @abstractmethod
-    def get_log_dir(self, job_id: int) -> str: ...
+    def get_tail_hint(self, job_id: int) -> str: ...

--- a/src/swiss_ai_model_launch/launchers/slurm_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/slurm_launcher.py
@@ -195,8 +195,8 @@ class SlurmLauncher(Launcher):
 
         return out_log, err_log
 
-    def get_log_dir(self, job_id: int) -> str:
-        return str(self._get_working_dir() / "logs" / str(job_id))
+    def get_tail_hint(self, job_id: int) -> str:
+        return f"tail -f ~/.sml/logs/{job_id}/log.out"
 
     async def cancel_job(self, job_id: int) -> None:
         proc = await asyncio.create_subprocess_exec(

--- a/src/swiss_ai_model_launch/mcp/server.py
+++ b/src/swiss_ai_model_launch/mcp/server.py
@@ -14,6 +14,7 @@ from swiss_ai_model_launch.cli.configuration import InitConfig
 from swiss_ai_model_launch.cli.healthcheck import ModelHealth, check_model_health
 from swiss_ai_model_launch.launchers import FirecRESTLauncher, Launcher, SlurmLauncher
 from swiss_ai_model_launch.launchers.job_status import JobStatus
+from swiss_ai_model_launch.launchers.launch_args import TELEMETRY_ENDPOINT
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.utils import create_salt
 
@@ -88,7 +89,6 @@ async def _create_launcher(
         raise RuntimeError("No partition specified. Call `establish` first, or set the SML_PARTITION env var.")
     config = InitConfig.load()
     launcher_type = config.get_non_none_value("launcher")
-    telemetry_endpoint = config.get_value("telemetry_endpoint")
 
     if launcher_type == "firecrest":
         if not system:
@@ -98,7 +98,7 @@ async def _create_launcher(
             system_name=system,
             partition=partition,
             reservation=reservation,
-            telemetry_endpoint=telemetry_endpoint,
+            telemetry_endpoint=TELEMETRY_ENDPOINT,
         )
     elif launcher_type == "slurm":
         return SlurmLauncher(
@@ -107,7 +107,7 @@ async def _create_launcher(
             account=grp.getgrgid(os.getgid()).gr_name,
             partition=partition,
             reservation=reservation,
-            telemetry_endpoint=telemetry_endpoint,
+            telemetry_endpoint=TELEMETRY_ENDPOINT,
         )
     else:
         raise RuntimeError(f"Launcher type '{launcher_type}' is not supported.")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,7 +38,6 @@ def sml_config_dir() -> Iterator[Path]:
     config.set_value("firecrest_client_id", os.environ["SML_FIRECREST_CLIENT_ID"])
     config.set_value("firecrest_client_secret", os.environ["SML_FIRECREST_CLIENT_SECRET"])
     config.set_value("cscs_api_key", os.environ["SML_CSCS_API_KEY"])
-    config.set_value("telemetry_endpoint", "")
     config.save()
 
     yield _BOOTSTRAP_DIR


### PR DESCRIPTION
## Summary
- **Telemetry endpoint is no longer user-configurable.** The `telemetry_endpoint` wizard step and `--telemetry-endpoint` flag are gone; URL is now a `TELEMETRY_ENDPOINT` constant in `launch_args.py`. Stored `telemetry_endpoint` values in existing `~/.sml/config.yml` are ignored on load (no migration needed).
- **Init wizard polish.** New `intro` field on `_ResolvableConfiguration` renders multi-line guidance before the prompt; URLs in the intro are auto-clickable in modern terminals (iTerm2, kitty, recent Terminal.app).
  - Launcher choice descriptions now point at the FirecREST setup guide and clarify what SLURM mode assumes.
  - FirecREST credential prompt links to the CSCS Developer Portal.
  - CSCS Serving API Key prompt links to `serving.swissai.svc.cscs.ch`.
- **Rename "CSCS API key" → "CSCS Serving API Key"** in all user-visible text (prompts, docs). Storage field `cscs_api_key` and env var `SML_CSCS_API_KEY` are unchanged, so existing configs and keyring entries keep working — no re-init required.
- **Post-launch output adds a `Tail:` line.** Per-launcher hint:
  - SLURM: `tail -f ~/.sml/logs/<id>/log.out`
  - FirecREST: `ssh <host> tail -f ~/.sml/logs/<id>/log.out` (with a note to substitute the user's SSH alias, since we can't reliably guess it)
- **`Launcher.get_log_dir` now returns `~/.sml/logs/<id>`** for both launchers. Previously the absolute `/users/<name>/...` path could be misread as the laptop user's home when launching via FirecREST.

## Test plan
- [x] `uv run pytest tests/unit` — 193 passing
- [ ] Manual: `sml init` (firecrest) — confirm new intros render with clickable links in your terminal
- [ ] Manual: `sml` end-to-end launch on SLURM — confirm `Tail:` shows the direct `tail -f` line
- [ ] Manual: `sml advanced` end-to-end launch via FirecREST — confirm `Tail:` shows the `ssh <host>` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)