### PR TITLE
Include model_launch_version in log payload

### DIFF
--- a/src/swiss_ai_model_launch/launchers/framework.py
+++ b/src/swiss_ai_model_launch/launchers/framework.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import shlex
 from typing import ClassVar
 
@@ -319,6 +320,7 @@ def _render_telemetry(launch_args: LaunchArgs) -> str:
     use_router = "true" if launch_args.use_router else "false"
     use_ocf = "false" if launch_args.disable_ocf else "true"
     fa = _compose_framework_args(launch_args)
+    sml_version = importlib.metadata.version("swiss-ai-model-launch")
     payload = (
         "{"
         '"user": "\'"${SLURM_JOB_USER}"\'", '
@@ -344,7 +346,8 @@ def _render_telemetry(launch_args: LaunchArgs) -> str:
         f'"ocf_enabled": {use_ocf}, '
         f'"ocf_bootstrap_addr": "{_resolve_ocf_bootstrap_addr(launch_args)}", '
         '"ocf_service_name": "llm", '
-        f'"ocf_service_port": {FRAMEWORK_PORT}'
+        f'"ocf_service_port": {FRAMEWORK_PORT}, '
+        f'"model_launch_version": "{sml_version}"'
         "}"
     )
     return (


### PR DESCRIPTION
## Summary
- Adds a `model_launch_version` field to the JSON posted to the launch-logging service (`_render_telemetry` in `framework.py`).
- Resolved at script-render time via `importlib.metadata.version("swiss-ai-model-launch")` — same pattern already used in `cli/main.py` for `--version`. The value is baked into the rendered sbatch script, so it reflects the version of the client that *submitted* the job.

## Motivation
A recent 422 storm in `#rms-model-launch-alerts` (~16 alerts from a single user across a day) turned out to be malformed JSON from a single client. Without a client version in the payload, we couldn't tell which release was emitting the bug or confirm when affected users upgraded. This unblocks both.


## Test plan
- [x] `uv run --frozen pytest tests/unit` — 196 / 196 pass (incl. 128-case `test_rendered_scripts_lint` matrix that runs `bash -n` + `shellcheck` over the rendered scripts)
- [x] `uv run --frozen ruff check .` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)