### PR TITLE
Configure max tokens for model health check

### DIFF
--- a/src/swiss_ai_model_launch/cli/healthcheck/checker.py
+++ b/src/swiss_ai_model_launch/cli/healthcheck/checker.py
@@ -3,7 +3,7 @@ import httpx
 from swiss_ai_model_launch.cli.healthcheck.model_health import ModelHealth
 
 _HEALTH_CHECK_URL = "https://api.swissai.svc.cscs.ch/v1/chat/completions"
-_MESSAGE = {"role": "user", "content": "Say hello."}
+_MESSAGE = {"role": "user", "content": 'Say the word "Hello". Nothing more.'}
 _TIMEOUT_SECONDS = 10
 _MAX_TOKENS = 16
 

--- a/src/swiss_ai_model_launch/cli/healthcheck/checker.py
+++ b/src/swiss_ai_model_launch/cli/healthcheck/checker.py
@@ -5,6 +5,7 @@ from swiss_ai_model_launch.cli.healthcheck.model_health import ModelHealth
 _HEALTH_CHECK_URL = "https://api.swissai.svc.cscs.ch/v1/chat/completions"
 _MESSAGE = {"role": "user", "content": "Say hello."}
 _TIMEOUT_SECONDS = 10
+_MAX_TOKENS = 16
 
 
 async def check_model_health(model_name: str, api_key: str) -> ModelHealth:
@@ -20,6 +21,7 @@ async def check_model_health(model_name: str, api_key: str) -> ModelHealth:
                     "model": model_name,
                     "messages": [_MESSAGE],
                     "stream": False,
+                    "max_tokens": _MAX_TOKENS,
                 },
                 timeout=_TIMEOUT_SECONDS,
             )


### PR DESCRIPTION
I spun up a model that was initialized with random weights. Since it's random it doesn't output the eos token when asked Say Hello and thus keeps generating a response until it timeouts. Adding a max token to the request fixes it by cutting the answer short even though the eos is not there. 