### PR TITLE
doc: Add long context checkpoint

### DIFF
--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-long-context-it5800.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-long-context-it5800.sh
@@ -3,18 +3,17 @@
 sml advanced \
   --partition normal \
   --slurm-nodes 1 \
-  --slurm-reservation SD-69241-apertus-1-5-0 \
   --slurm-time 12:00:00 \
   --serving-framework vllm \
   --slurm-environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-8b-sft-256k-adam-lr6e-5-constant-128n_5800 \
     --served-model-name swiss-ai/Apertus-1.5-8B-Instruct-LC-5800 \
-    --tokenizer /capstor/scratch/cscs/dtamayomela/tokenizer_fixed \
+    --tokenizer /capstor/store/cscs/swissai/infra01/hf_tokenizers/tokenizers/Apertus-v1p5-tool_output_toks-think_toks \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \
     --trust-remote-code \
     --trust-request-chat-template \
-    --max-model-len 8192 \
+    --max-model-len 262144 \
     --skip-mm-profiling \
     --gpu-memory-utilization 0.6"

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-long-context-it5800.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-long-context-it5800.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+sml advanced \
+  --partition normal \
+  --slurm-nodes 1 \
+  --slurm-reservation SD-69241-apertus-1-5-0 \
+  --slurm-time 12:00:00 \
+  --serving-framework vllm \
+  --slurm-environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
+  --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-8b-sft-256k-adam-lr6e-5-constant-128n_5800 \
+    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct-LC-5800 \
+    --tokenizer /capstor/scratch/cscs/dtamayomela/tokenizer_fixed \
+    --tensor-parallel-size 4 \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --trust-remote-code \
+    --trust-request-chat-template \
+    --max-model-len 8192 \
+    --skip-mm-profiling \
+    --gpu-memory-utilization 0.6"


### PR DESCRIPTION
Add a launcher for the following checkpoint:

```
/capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-8b-sft-256k-adam-lr6e-5-constant-128n_5800 
```

The flag `--skip-mm-profiling` was added after a conversation with @Anunay-Yadav ([slack](https://swissai-initiative.slack.com/archives/C0B7DM9PNAE/p1780320008661349?thread_ts=1780318676.373169&cid=C0B7DM9PNAE)) to support multimodality.