### PR TITLE
Apertus vllm serving image: Commit hashes pin  + hf cache directory c…

### DIFF
--- a/images/vllm_apertus_1.5/Dockerfile
+++ b/images/vllm_apertus_1.5/Dockerfile
@@ -74,7 +74,7 @@ WORKDIR /workspace
 
 RUN git clone --branch apertus_integration https://github.com/swiss-ai/vllm.git /workspace/vllm && \
     git -C /workspace/vllm checkout 09eae2122ed71aa27765bbbf8c043009bfb86477 && \
-    git clone https://github.com/baaivision/Emu3.5.git /workspace/Emu3.5 && \
+    git clone https://github.com/swiss-ai/Emu3.5.git /workspace/Emu3.5 && \
     git -C /workspace/Emu3.5 checkout 8fcf1da48f9c5252fe0a0b8dc842e07b6efcd745 && \
     git clone https://github.com/swiss-ai/benchmark-audio-tokenizer.git /workspace/benchmark-audio-tokenizer && \
     git -C /workspace/benchmark-audio-tokenizer checkout f8fe507212aa672a067baddb157b92ba3cfe9467 && \
@@ -102,8 +102,10 @@ RUN set -eu; \
     --python /opt/venv/bin/python \
     --reinstall-package vllm \
     --no-build-isolation \
-    --editable . \
+    --editable .[audio] \
     --torch-backend=auto;
+
+RUN uv pip install --python /opt/venv/bin/python scipy ruff tblib pytest  "fastapi[standard]>=0.115.0,<0.137.0"
 
 RUN <<'EOF'
 python - <<'PY'
@@ -120,7 +122,6 @@ except Exception as exc:
 else:
     print("vLLM native extension import check passed.")
 PY
-uv pip install --python /opt/venv/bin/python scipy ruff tblib pytest vllm[audio]  "fastapi[standard]>=0.115.0,<0.137.0"
 printf '%s\n' \
     'Production CUDA 13 image with local vLLM source built inline in Dockerfile.' \
     'Included paths:' \

--- a/images/vllm_apertus_1.5/Dockerfile
+++ b/images/vllm_apertus_1.5/Dockerfile
@@ -73,13 +73,16 @@ RUN CUDNN_DIR=$(dirname "$(find /usr -name cudnn.h -print -quit)") && \
 WORKDIR /workspace
 
 RUN git clone --branch apertus_integration https://github.com/swiss-ai/vllm.git /workspace/vllm && \
+    git -C /workspace/vllm checkout 09eae2122ed71aa27765bbbf8c043009bfb86477 && \
     git clone https://github.com/baaivision/Emu3.5.git /workspace/Emu3.5 && \
+    git -C /workspace/Emu3.5 checkout 8fcf1da48f9c5252fe0a0b8dc842e07b6efcd745 && \
     git clone https://github.com/swiss-ai/benchmark-audio-tokenizer.git /workspace/benchmark-audio-tokenizer && \
+    git -C /workspace/benchmark-audio-tokenizer checkout f8fe507212aa672a067baddb157b92ba3cfe9467 && \
     git -C /workspace/benchmark-audio-tokenizer submodule update --init --recursive
 
 ENV VLLM_REPO=/workspace/vllm \
     EMU35=/workspace/Emu3.5 \
-    ec=/workspace/benchmark-audio-tokenizer \
+    VLLM_APERTUS_AUDIO_TOKENIZER_CODEBASE=/workspace/benchmark-audio-tokenizer \
     PYTHONPATH=/workspace/vllm:${PYTHONPATH} \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/venv/lib/python3.12/site-packages/torch/lib \
     VLLM_APERTUS_EMU35_CODEBASE=/workspace/Emu3.5
@@ -117,7 +120,7 @@ except Exception as exc:
 else:
     print("vLLM native extension import check passed.")
 PY
-uv pip install --python /opt/venv/bin/python scipy ruff tblib pytest
+uv pip install --python /opt/venv/bin/python scipy ruff tblib pytest vllm[audio]  "fastapi[standard]>=0.115.0,<0.137.0"
 printf '%s\n' \
     'Production CUDA 13 image with local vLLM source built inline in Dockerfile.' \
     'Included paths:' \


### PR DESCRIPTION
Changes:

1. Commit pins added
2. fastapi[standard] released a version on june 15th which was causing issues, so had to pin it to the working version.
3. HF cache directory changes merged.