### PR TITLE
Build images for amd64 + arm64 and merge into multi-arch manifest

### DIFF
--- a/.github/scripts/build_image.py
+++ b/.github/scripts/build_image.py
@@ -25,6 +25,7 @@ _TERMINAL_STATES = {
 
 def _build_slurm_script(
     image_name: str,
+    arch: str,
     account: str,
     partition: str,
     reservation: str | None,
@@ -34,11 +35,13 @@ def _build_slurm_script(
     ghcr_actor: str,
 ) -> str:
     reservation_line = f"#SBATCH --reservation={reservation}" if reservation else ""
-    ghcr_image = f"ghcr.io/swiss-ai/{image_name}:latest"
+    # Push to an arch-specific tag; a later merge step combines the per-arch
+    # tags into a single multi-arch manifest list under ":latest".
+    ghcr_image = f"ghcr.io/swiss-ai/{image_name}:latest-{arch}"
     return dedent(
         f"""
         #!/bin/bash
-        #SBATCH --job-name=build-{image_name}
+        #SBATCH --job-name=build-{image_name}-{arch}
         #SBATCH --nodes=1
         #SBATCH --ntasks=1
         #SBATCH --cpus-per-task=64
@@ -57,8 +60,8 @@ def _build_slurm_script(
         export XDG_RUNTIME_DIR="${{TMPDIR:-/tmp}}/podman-runtime-$$"
         mkdir -p "${{XDG_RUNTIME_DIR}}"
 
-        IMAGE_TAG="{image_name}:${{SLURM_JOB_ID}}"
-        SCRATCH_SQSH="${{SCRATCH}}/{image_name}.sqsh"
+        IMAGE_TAG="{image_name}-{arch}:${{SLURM_JOB_ID}}"
+        SCRATCH_SQSH="${{SCRATCH}}/{image_name}-{arch}.sqsh"
 
         cleanup() {{
             podman logout ghcr.io 2>/dev/null || true
@@ -120,14 +123,47 @@ async def _print_logs(
                 print(f"  Could not retrieve {suffix} log: {e}")
 
 
-async def main(image_name: str) -> int:
+def _arch_env(base_key: str, arch: str) -> str | None:
+    """Resolve a per-arch FireCREST setting.
+
+    arm64 (the original Grace cluster) uses the base var, e.g. SML_FIRECREST_URL.
+    Other arches use a strictly arch-suffixed var, e.g. SML_FIRECREST_URL_AMD64,
+    with NO fallback to the base var — falling back would silently build on the
+    wrong cluster. Credentials and token URI are shared across clusters.
+    Reservation is optional per arch (e.g. the amd64 cluster has none).
+    """
+    if arch == "arm64":
+        return os.environ.get(base_key)
+    return os.environ.get(f"{base_key}_{arch.upper()}")
+
+
+async def main(image_name: str, arch: str) -> int:
+    # Shared across both clusters.
     client_id = os.environ["SML_FIRECREST_CLIENT_ID"]
     client_secret = os.environ["SML_FIRECREST_CLIENT_SECRET"]
     token_uri = os.environ["SML_FIRECREST_TOKEN_URI"]
-    firecrest_url = os.environ["SML_FIRECREST_URL"]
-    system_name = os.environ["SML_FIRECREST_SYSTEM"]
-    partition = os.environ["SML_PARTITION"]
-    reservation = os.environ.get("SML_RESERVATION")
+
+    # Per-arch: different cluster reached via a different FireCREST endpoint.
+    firecrest_url = _arch_env("SML_FIRECREST_URL", arch)
+    system_name = _arch_env("SML_FIRECREST_SYSTEM", arch)
+    partition = _arch_env("SML_PARTITION", arch)
+    reservation = _arch_env("SML_RESERVATION", arch)
+    missing = [
+        name
+        for name, val in (
+            ("SML_FIRECREST_URL", firecrest_url),
+            ("SML_FIRECREST_SYSTEM", system_name),
+            ("SML_PARTITION", partition),
+        )
+        if not val
+    ]
+    if missing:
+        print(
+            f"Missing FireCREST config for arch '{arch}': {', '.join(missing)} "
+            f"(set <VAR>_{arch.upper()} or the base <VAR>)",
+            file=sys.stderr,
+        )
+        return 1
 
     ghcr_token = os.environ["GHCR_TOKEN"]
     ghcr_actor = os.environ["GHCR_ACTOR"]
@@ -139,7 +175,9 @@ async def main(image_name: str) -> int:
     username = user_info["user"]["name"]
     account = user_info["group"]["name"]
 
-    remote_build_dir = f"/users/{username}/.sml/image-builds/{image_name}"
+    # Arch-suffixed so concurrent arm64/amd64 builds don't clobber each other's
+    # uploaded build context on a shared home filesystem.
+    remote_build_dir = f"/users/{username}/.sml/image-builds/{image_name}-{arch}"
     remote_logs_dir = f"/users/{username}/.sml/image-builds/logs"
 
     print("Creating remote directories...")
@@ -160,10 +198,13 @@ async def main(image_name: str) -> int:
                 blocking=True,
             )
 
-    output_sqsh = f"{_CAPSTOR_IMAGES}/{image_name}.sqsh"
+    # Arch-suffixed: capstor is a shared store, so per-arch builds must not
+    # write to the same path.
+    output_sqsh = f"{_CAPSTOR_IMAGES}/{image_name}-{arch}.sqsh"
 
     script = _build_slurm_script(
         image_name=image_name,
+        arch=arch,
         account=account,
         partition=partition,
         reservation=reservation,
@@ -205,7 +246,12 @@ async def main(image_name: str) -> int:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <image_name>", file=sys.stderr)
+    if len(sys.argv) not in (2, 3):
+        print(f"Usage: {sys.argv[0]} <image_name> [arch]", file=sys.stderr)
         sys.exit(1)
-    sys.exit(asyncio.run(main(sys.argv[1])))
+    image_arg = sys.argv[1]
+    arch_arg = sys.argv[2] if len(sys.argv) == 3 else "arm64"
+    if arch_arg not in ("arm64", "amd64"):
+        print(f"Unsupported arch '{arch_arg}' (expected arm64 or amd64)", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(asyncio.run(main(image_arg, arch_arg)))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           echo "Detected images: $IMAGES"
 
   build:
-    name: Docker Build ${{ matrix.image }}
+    name: Docker Build ${{ matrix.image }} (${{ matrix.arch }})
     needs: [detect-changes, static-checks]
     if: github.event.pull_request.draft != true && needs.detect-changes.outputs.images != '[]' && needs.detect-changes.outputs.images != ''
     runs-on: ubuntu-latest
@@ -67,15 +67,25 @@ jobs:
     strategy:
       matrix:
         image: ${{ fromJson(needs.detect-changes.outputs.images) }}
+        # Each arch is built natively on its own cluster, reached via a
+        # different FireCREST endpoint, and pushed to a :latest-<arch> tag.
+        # The merge-manifests job combines them into a multi-arch :latest.
+        arch: [arm64, amd64]
       fail-fast: false
     env:
       SML_FIRECREST_CLIENT_ID: ${{ secrets.SML_FIRECREST_CLIENT_ID }}
       SML_FIRECREST_CLIENT_SECRET: ${{ secrets.SML_FIRECREST_CLIENT_SECRET }}
       SML_FIRECREST_TOKEN_URI: ${{ secrets.SML_FIRECREST_TOKEN_URI }}
-      SML_FIRECREST_URL: ${{ secrets.SML_FIRECREST_URL }}
-      SML_FIRECREST_SYSTEM: ${{ secrets.SML_FIRECREST_SYSTEM }}
-      SML_PARTITION: ${{ secrets.SML_PARTITION }}
-      SML_RESERVATION: ${{ secrets.SML_RESERVATION }}
+      # arm64 (Grace) cluster — base vars.
+      SML_FIRECREST_URL: ${{ vars.SML_FIRECREST_URL }}
+      SML_FIRECREST_SYSTEM: ${{ vars.SML_FIRECREST_SYSTEM }}
+      SML_PARTITION: ${{ vars.SML_PARTITION }}
+      SML_RESERVATION: ${{ vars.SML_RESERVATION }}
+      # amd64 (x86_64) cluster — different URL / system / partition, same creds.
+      # No reservation on this cluster.
+      SML_FIRECREST_URL_AMD64: ${{ vars.SML_FIRECREST_URL_AMD64 }}
+      SML_FIRECREST_SYSTEM_AMD64: ${{ vars.SML_FIRECREST_SYSTEM_AMD64 }}
+      SML_PARTITION_AMD64: ${{ vars.SML_PARTITION_AMD64 }}
       GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GHCR_ACTOR: ${{ github.actor }}
     steps:
@@ -85,14 +95,14 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build-sentinel
-          key: build-${{ matrix.image }}-${{ hashFiles(format('images/{0}/**', matrix.image)) }}
+          key: build-${{ matrix.image }}-${{ matrix.arch }}-${{ hashFiles(format('images/{0}/**', matrix.image)) }}
       - uses: ./.github/actions/setup
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           python-version: "3.12"
       - name: Build image and save sqsh
         if: steps.cache.outputs.cache-hit != 'true'
-        run: python .github/scripts/build_image.py "${{ matrix.image }}"
+        run: python .github/scripts/build_image.py "${{ matrix.image }}" "${{ matrix.arch }}"
         timeout-minutes: 300
       - name: Save build cache
         if: steps.cache.outputs.cache-hit != 'true'
@@ -101,7 +111,39 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: .build-sentinel
-          key: build-${{ matrix.image }}-${{ hashFiles(format('images/{0}/**', matrix.image)) }}
+          key: build-${{ matrix.image }}-${{ matrix.arch }}-${{ hashFiles(format('images/{0}/**', matrix.image)) }}
+
+  merge-manifests:
+    name: Merge multi-arch manifest ${{ matrix.image }}
+    needs: [detect-changes, build]
+    # Only if every arch build succeeded — a partial set would yield a
+    # single-arch manifest.
+    if: needs.build.result == 'success' && needs.detect-changes.outputs.images != '[]' && needs.detect-changes.outputs.images != ''
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        image: ${{ fromJson(needs.detect-changes.outputs.images) }}
+      fail-fast: false
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch :latest
+        env:
+          IMAGE: ghcr.io/swiss-ai/${{ matrix.image }}
+        run: |
+          docker buildx imagetools create -t "${IMAGE}:latest" \
+            "${IMAGE}:latest-arm64" \
+            "${IMAGE}:latest-amd64"
+      - name: Inspect
+        env:
+          IMAGE: ghcr.io/swiss-ai/${{ matrix.image }}
+        run: docker buildx imagetools inspect "${IMAGE}:latest"
 
   test-lightweight:
     name: Integration Tests (lightweight)
@@ -118,11 +160,11 @@ jobs:
       SML_CSCS_API_KEY: ${{ secrets.SML_CSCS_API_KEY }}
       SML_FIRECREST_CLIENT_ID: ${{ secrets.SML_FIRECREST_CLIENT_ID }}
       SML_FIRECREST_CLIENT_SECRET: ${{ secrets.SML_FIRECREST_CLIENT_SECRET }}
-      SML_FIRECREST_SYSTEM: ${{ secrets.SML_FIRECREST_SYSTEM }}
+      SML_FIRECREST_SYSTEM: ${{ vars.SML_FIRECREST_SYSTEM }}
       SML_FIRECREST_TOKEN_URI: ${{ secrets.SML_FIRECREST_TOKEN_URI }}
-      SML_FIRECREST_URL: ${{ secrets.SML_FIRECREST_URL }}
-      SML_PARTITION: ${{ secrets.SML_PARTITION }}
-      SML_RESERVATION: ${{ secrets.SML_RESERVATION }}
+      SML_FIRECREST_URL: ${{ vars.SML_FIRECREST_URL }}
+      SML_PARTITION: ${{ vars.SML_PARTITION }}
+      SML_RESERVATION: ${{ vars.SML_RESERVATION }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
@@ -144,11 +186,11 @@ jobs:
       SML_CSCS_API_KEY: ${{ secrets.SML_CSCS_API_KEY }}
       SML_FIRECREST_CLIENT_ID: ${{ secrets.SML_FIRECREST_CLIENT_ID }}
       SML_FIRECREST_CLIENT_SECRET: ${{ secrets.SML_FIRECREST_CLIENT_SECRET }}
-      SML_FIRECREST_SYSTEM: ${{ secrets.SML_FIRECREST_SYSTEM }}
+      SML_FIRECREST_SYSTEM: ${{ vars.SML_FIRECREST_SYSTEM }}
       SML_FIRECREST_TOKEN_URI: ${{ secrets.SML_FIRECREST_TOKEN_URI }}
-      SML_FIRECREST_URL: ${{ secrets.SML_FIRECREST_URL }}
-      SML_PARTITION: ${{ secrets.SML_PARTITION }}
-      SML_RESERVATION: ${{ secrets.SML_RESERVATION }}
+      SML_FIRECREST_URL: ${{ vars.SML_FIRECREST_URL }}
+      SML_PARTITION: ${{ vars.SML_PARTITION }}
+      SML_RESERVATION: ${{ vars.SML_RESERVATION }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
@@ -169,11 +211,11 @@ jobs:
       SML_CSCS_API_KEY: ${{ secrets.SML_CSCS_API_KEY }}
       SML_FIRECREST_CLIENT_ID: ${{ secrets.SML_FIRECREST_CLIENT_ID }}
       SML_FIRECREST_CLIENT_SECRET: ${{ secrets.SML_FIRECREST_CLIENT_SECRET }}
-      SML_FIRECREST_SYSTEM: ${{ secrets.SML_FIRECREST_SYSTEM }}
+      SML_FIRECREST_SYSTEM: ${{ vars.SML_FIRECREST_SYSTEM }}
       SML_FIRECREST_TOKEN_URI: ${{ secrets.SML_FIRECREST_TOKEN_URI }}
-      SML_FIRECREST_URL: ${{ secrets.SML_FIRECREST_URL }}
-      SML_PARTITION: ${{ secrets.SML_PARTITION }}
-      SML_RESERVATION: ${{ secrets.SML_RESERVATION }}
+      SML_FIRECREST_URL: ${{ vars.SML_FIRECREST_URL }}
+      SML_PARTITION: ${{ vars.SML_PARTITION }}
+      SML_RESERVATION: ${{ vars.SML_RESERVATION }}
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, labeled, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Single image dir under images/ to build (leave empty to build all)."
+        required: false
+        default: ""
 
 jobs:
   static-checks:
@@ -27,7 +33,10 @@ jobs:
       - name: Detect changed image directories
         id: detect
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.image }}" ]; then
+            # Manual run targeting one image; validated against images/ below.
+            CHANGED="${{ inputs.image }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}" "${{ github.sha }}" -- images/ \
               | grep '^images/' \
               | cut -d/ -f2 \


### PR DESCRIPTION
## Why
The published `vllm_apertus_1.5` image (and all `images/*`) was **arm64-only**: `build_image.py` submitted a single FireCREST/Slurm `podman build` on the Grace (arm64) cluster and pushed straight to `:latest`. PR #152 only made the *Dockerfile* arch-agnostic, not the build pipeline.

## What
- **`build_image.py`** takes an `arch` argument, resolves per-arch FireCREST config, and pushes to `:latest-<arch>`. Resolution is **strict**: arm64 uses the base vars, other arches use `<VAR>_<ARCH>` only — no fallback, since falling back would silently build on the wrong cluster. amd64 has no reservation. The sqsh / remote build-dir / job-name are arch-suffixed (capstor is a shared store → concurrent builds would otherwise collide).
- **`ci.yml`** gains an `arch: [arm64, amd64]` matrix (arm64 → Clariden, amd64 → Beverin) and a new **`merge-manifests`** job that runs `docker buildx imagetools create` to combine the per-arch tags into a multi-arch `:latest`.
- Non-sensitive FireCREST config (`URL`/`SYSTEM`/`PARTITION`/`RESERVATION`, base + amd64) moved from **secrets → Actions variables**; only the OAuth credentials (`CLIENT_ID`/`CLIENT_SECRET`/`TOKEN_URI`) remain secrets.

## Required config (already set)
Repository **variables**: `SML_FIRECREST_URL`, `SML_FIRECREST_SYSTEM`, `SML_PARTITION`, `SML_RESERVATION`, `SML_FIRECREST_URL_AMD64`, `SML_FIRECREST_SYSTEM_AMD64`, `SML_PARTITION_AMD64` (no amd64 reservation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)