### PR TITLE
fix(vllm_apertus_1.5): align Dockerfile ENTRYPOINT with upstream vLLM image

### DIFF
--- a/images/vllm_apertus_1.5/Dockerfile
+++ b/images/vllm_apertus_1.5/Dockerfile
@@ -140,3 +140,5 @@ printf '%s\n' \
     '  /workspace/benchmark-audio-tokenizer (VLLM_APERTUS_AUDIO_TOKENIZER_CODEBASE)' \
     > /etc/motd
 EOF
+
+ENTRYPOINT ["vllm", "serve"]


### PR DESCRIPTION
### Motivation

The `vllm_apertus_1.5` image is intended to run the vLLM OpenAI-compatible server, but it previously defined no `ENTRYPOINT` (or `CMD`). Without this, users must know and manually type the `vllm serve` command on every `docker run`, which is error-prone and breaks parity with the official `vllm/vllm-openai` image.

### Change

Add the standard vLLM instruction at the end of the Dockerfile:

```dockerfile
ENTRYPOINT ["vllm", "serve"]
```

This aligns vllm_apertus_1.5 with the vllm-project/vllm (https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile) Dockerfile, where the vllm-openai target uses the same ENTRYPOINT.