### PR TITLE
Dependency on absolute repos removed and apertus vllm serving updated

### DIFF
--- a/images/vllm_apertus_1.5/Dockerfile
+++ b/images/vllm_apertus_1.5/Dockerfile
@@ -77,10 +77,8 @@ RUN CUDNN_DIR=$(dirname "$(find /usr -name cudnn.h -print -quit)") && \
 
 WORKDIR /workspace
 
-# RUN git clone --branch apertus_integration https://github.com/swiss-ai/vllm.git /workspace/vllm && \
-#     git -C /workspace/vllm checkout 09eae2122ed71aa27765bbbf8c043009bfb86477
-
-RUN git clone --branch audio-tokenizer-prod-cleanup https://github.com/Anunay-Yadav/vllm.git /workspace/vllm
+RUN git clone --branch apertus_integration https://github.com/swiss-ai/vllm.git /workspace/vllm && \
+    git -C /workspace/vllm checkout 40a5516b780daa7ee412295904b133bb4b1e43d2
 
 ENV VLLM_REPO=/workspace/vllm \
     PYTHONPATH=/workspace/vllm:${PYTHONPATH} \

--- a/images/vllm_apertus_1.5/Dockerfile
+++ b/images/vllm_apertus_1.5/Dockerfile
@@ -77,20 +77,14 @@ RUN CUDNN_DIR=$(dirname "$(find /usr -name cudnn.h -print -quit)") && \
 
 WORKDIR /workspace
 
-RUN git clone --branch apertus_integration https://github.com/swiss-ai/vllm.git /workspace/vllm && \
-    git -C /workspace/vllm checkout 09eae2122ed71aa27765bbbf8c043009bfb86477 && \
-    git clone https://github.com/swiss-ai/Emu3.5.git /workspace/Emu3.5 && \
-    git -C /workspace/Emu3.5 checkout 8fcf1da48f9c5252fe0a0b8dc842e07b6efcd745 && \
-    git clone https://github.com/swiss-ai/benchmark-audio-tokenizer.git /workspace/benchmark-audio-tokenizer && \
-    git -C /workspace/benchmark-audio-tokenizer checkout f8fe507212aa672a067baddb157b92ba3cfe9467 && \
-    git -C /workspace/benchmark-audio-tokenizer submodule update --init --recursive
+# RUN git clone --branch apertus_integration https://github.com/swiss-ai/vllm.git /workspace/vllm && \
+#     git -C /workspace/vllm checkout 09eae2122ed71aa27765bbbf8c043009bfb86477
+
+RUN git clone --branch audio-tokenizer-prod-cleanup https://github.com/Anunay-Yadav/vllm.git /workspace/vllm
 
 ENV VLLM_REPO=/workspace/vllm \
-    EMU35=/workspace/Emu3.5 \
-    VLLM_APERTUS_AUDIO_TOKENIZER_CODEBASE=/workspace/benchmark-audio-tokenizer \
     PYTHONPATH=/workspace/vllm:${PYTHONPATH} \
-    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/venv/lib/python${PYTHON_VERSION}/site-packages/torch/lib \
-    VLLM_APERTUS_EMU35_CODEBASE=/workspace/Emu3.5
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/venv/lib/python${PYTHON_VERSION}/site-packages/torch/lib
 
 WORKDIR /workspace/vllm
 
@@ -112,7 +106,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --python /opt/venv/bin/python \
     --reinstall-package vllm \
     --no-build-isolation \
-    --editable .[audio] \
+    --editable .[audio,apertus] \
     --torch-backend=auto;
 
 RUN uv pip install --python /opt/venv/bin/python scipy ruff tblib pytest  "fastapi[standard]>=0.115.0,<0.137.0"

--- a/images/vllm_apertus_1.5/Dockerfile
+++ b/images/vllm_apertus_1.5/Dockerfile
@@ -104,7 +104,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --python /opt/venv/bin/python \
     --reinstall-package vllm \
     --no-build-isolation \
-    --editable .[audio,apertus] \
+    --editable ".[audio,apertus]" \
     --torch-backend=auto;
 
 RUN uv pip install --python /opt/venv/bin/python scipy ruff tblib pytest  "fastapi[standard]>=0.115.0,<0.137.0"


### PR DESCRIPTION
PR removes redundant dependency on cloned repos for apertus vllm serving.

- Emu tokenizer codebase dependency removed
- Audio tokenizer codebase dependency removed
- Environment flags for passing tokenizer config removed

Todo: it still depends on a custom branch which will be updated once the pr is merged.

Testing:

- Verified by serving apertus 1p5 with custom prompts for all modality combinations and base64+url passing of multimodal objects 