### PR TITLE
Precompiled wheel that supports cuda130 used

### DIFF
--- a/images/vllm_apertus_1.5_infomaniak/Dockerfile
+++ b/images/vllm_apertus_1.5_infomaniak/Dockerfile
@@ -9,14 +9,12 @@ ARG VLLM_MAIN_CUDA_VERSION=13.0
 ARG TORCH_CUDA_ARCH_LIST="7.5 8.0 8.6 8.9 9.0 10.0 11.0 12.0+PTX"
 ARG TARGETARCH
 
-# Build vLLM from the swiss-ai mirror of the Infomaniak fork (apertus-1-5
-# branch): the Infomaniak tip plus Apertus multimodal runtime fixes.
-# https://github.com/swiss-ai/infomaniak-vllm/tree/apertus-1-5
-ARG VLLM_REPO_URL=https://github.com/swiss-ai/infomaniak-vllm.git
-ARG VLLM_REPO_BRANCH=apertus-1-5
-ARG VLLM_REPO_COMMIT=08a8a4af3fb904ab809c6347b785407f180ccf22
-ARG SWISS_AI_VLLM_COMMIT=aa64d5e6dca80cb4a9e3cb6ba4b3591a49d268a8
-ARG VLLM_PRECOMPILED_WHEEL_LOCATION=https://wheels.vllm.ai/08a8a4af3fb904ab809c6347b785407f180ccf22/vllm-0.23.1rc1.dev719%2Bg08a8a4af3-cp38-abi3-manylinux_2_28_aarch64.whl
+# https://github.com/swiss-ai/vllm/tree/serving
+ARG VLLM_REPO_URL=https://github.com/swiss-ai/vllm.git
+ARG VLLM_REPO_BRANCH=serving
+ARG VLLM_REPO_COMMIT=ae6170f874a7c66512bd24aa714b3a02f8a61838
+ARG SWISS_AI_VLLM_COMMIT=7e4af082a9b04ef78242393f2aa7add0e6d3a911
+ARG VLLM_PRECOMPILED_WHEEL_LOCATION=https://wheels.vllm.ai/ae6170f874a7c66512bd24aa714b3a02f8a61838/vllm-0.23.1rc1.dev977%2Bgae6170f87-cp38-abi3-manylinux_2_28_aarch64.whl
 
 ENV TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
     MAX_JOBS="${MAX_JOBS}" \
@@ -51,7 +49,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Rust toolchain — the apertus-1-5 branch builds a Rust extension via setuptools-rust
+# Rust toolchain — the serving fixes branch builds a Rust extension via setuptools-rust
 # (rust-toolchain.toml pins channel 1.95).
 ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo
@@ -113,7 +111,8 @@ RUN git clone --branch "${VLLM_REPO_BRANCH}" --single-branch "${VLLM_REPO_URL}" 
 # /workspace/vllm onto sys.path shadows the editable-install finder and hides
 # the compiled extensions (vllm._C) built by setup.py.
 ENV VLLM_REPO=/workspace/vllm \
-    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/venv/lib/python${PYTHON_VERSION}/site-packages/torch/lib
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/venv/lib/python${PYTHON_VERSION}/site-packages/torch/lib \
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm
 
 WORKDIR /workspace/vllm
 
@@ -170,8 +169,8 @@ else:
     print("vLLM native extension import check passed.")
 PY
 printf '%s\n' \
-    'Production CUDA 13 image with Infomaniak vLLM (apertus-1-5 branch) built inline in Dockerfile.' \
-    'Source: https://github.com/Infomaniak/vllm/tree/apertus-1-5' \
+    'Production CUDA 13 image with Swiss AI vLLM (serving branch) built inline in Dockerfile.' \
+    'Source: https://github.com/swiss-ai/vllm/tree/serving' \
     'Included path: /workspace/vllm' \
     > /etc/motd
 EOF

--- a/images/vllm_apertus_1.5_infomaniak/Dockerfile
+++ b/images/vllm_apertus_1.5_infomaniak/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/nvidia/cuda:13.0.0-cudnn-devel-ubuntu24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG MAX_JOBS=8
+ARG MAX_JOBS=32
 ARG CUDA_VERSION_PATH=cu130
 ARG PYTHON_VERSION=3.12
 ARG RUST_TOOLCHAIN=1.95.0
@@ -14,7 +14,9 @@ ARG TARGETARCH
 # https://github.com/swiss-ai/infomaniak-vllm/tree/apertus-1-5
 ARG VLLM_REPO_URL=https://github.com/swiss-ai/infomaniak-vllm.git
 ARG VLLM_REPO_BRANCH=apertus-1-5
-ARG VLLM_REPO_COMMIT=aa64d5e6dca80cb4a9e3cb6ba4b3591a49d268a8
+ARG VLLM_REPO_COMMIT=08a8a4af3fb904ab809c6347b785407f180ccf22
+ARG SWISS_AI_VLLM_COMMIT=aa64d5e6dca80cb4a9e3cb6ba4b3591a49d268a8
+ARG VLLM_PRECOMPILED_WHEEL_LOCATION=https://wheels.vllm.ai/08a8a4af3fb904ab809c6347b785407f180ccf22/vllm-0.23.1rc1.dev719%2Bg08a8a4af3-cp38-abi3-manylinux_2_28_aarch64.whl
 
 ENV TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
     MAX_JOBS="${MAX_JOBS}" \
@@ -23,7 +25,11 @@ ENV TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
     UV_HTTP_TIMEOUT=500 \
     UV_INDEX_STRATEGY=unsafe-best-match \
     UV_LINK_MODE=copy \
-    VLLM_MAIN_CUDA_VERSION="${VLLM_MAIN_CUDA_VERSION}"
+    VLLM_USE_PRECOMPILED=1 \
+    VLLM_MAIN_CUDA_VERSION="${VLLM_MAIN_CUDA_VERSION}" \
+    VLLM_PRECOMPILED_WHEEL_VARIANT="${CUDA_VERSION_PATH}" \
+    VLLM_PRECOMPILED_WHEEL_COMMIT="${VLLM_REPO_COMMIT}" \
+    VLLM_PRECOMPILED_WHEEL_LOCATION="${VLLM_PRECOMPILED_WHEEL_LOCATION}"
 
 # Keep host NVIDIA driver libraries first to avoid CUDA Error 803
 # from loading cuda-compat stubs in /usr/local/cuda/compat.
@@ -100,7 +106,7 @@ WORKDIR /workspace
 
 # Clone the branch and pin the exact commit for reproducibility.
 RUN git clone --branch "${VLLM_REPO_BRANCH}" --single-branch "${VLLM_REPO_URL}" /workspace/vllm && \
-    git -C /workspace/vllm checkout "${VLLM_REPO_COMMIT}" && \
+    git -C /workspace/vllm checkout "${SWISS_AI_VLLM_COMMIT}" && \
     git -C /workspace/vllm rev-parse HEAD
 
 # No PYTHONPATH here: the editable install already exposes the package. Forcing
@@ -111,14 +117,15 @@ ENV VLLM_REPO=/workspace/vllm \
 
 WORKDIR /workspace/vllm
 
-# Build and install vLLM from source (compiles CUDA + Rust extensions).
+# Install vLLM from the editable source tree, reusing the CUDA 13 precompiled
+# native extensions for the pinned commit.
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --mount=type=cache,target=/root/.cache/ccache,sharing=locked \
-    uv pip install \
+    VLLM_USE_PRECOMPILED=1 uv -v pip install \
     --python /opt/venv/bin/python \
     --reinstall-package vllm \
     --no-build-isolation \
-    --editable .
+    --editable .[audio]
 
 RUN uv pip install --python /opt/venv/bin/python scipy ruff tblib pytest "fastapi[standard]>=0.115.0,<0.137.0"
 


### PR DESCRIPTION
Updates
1. Precompiled wheel used that supports cuda130
2. Precompiled wheel pinned with last valid vllm commit.
3. Tested with all modality requests and serving on a local one node setup


Setup has problems with --tensor-parallel-size > 1 (causes the buffer size issue) this is a vllm issue afaik it is not because of our implementation. I tested apertus 1 version and it occurs there aswell. 
To run the vllm serve regardless use. 

export VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm


https://huggingface.co/apertus-ai/Apertus-v1.5-70B-Prerelease-2607/discussions/5

You need the following changes inside the model directory to serve the model