### PR TITLE
Publish PR image builds to a pr-<N> channel, not :latest

### DIFF
--- a/.github/scripts/build_image.py
+++ b/.github/scripts/build_image.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import re
 import sys
 import tempfile
 import time
@@ -11,6 +12,10 @@ from textwrap import dedent
 import firecrest as f7t
 
 _CAPSTOR_IMAGES = "/capstor/store/cscs/swissai/infra01/container-images/ci"
+_RELEASE_CHANNEL = "latest"
+# Anything outside this set lands in a filesystem path and a registry tag, so
+# it must not contain path separators or shell metacharacters.
+_CHANNEL_RE = re.compile(r"^(latest|pr-\d+)$")
 _POLL_INTERVAL = 60
 _TIMEOUT = 4 * 3600
 _TERMINAL_STATES = {
@@ -23,9 +28,22 @@ _TERMINAL_STATES = {
 }
 
 
+def sqsh_path(image_name: str, arch: str, channel: str) -> str:
+    """Where a build's squashfs lands on the shared capstor store.
+
+    The release channel keeps its historical flat path, because the env TOMLs
+    and other consumers point straight at it. Pre-release channels get their
+    own subdirectory so a PR build can never overwrite what main published.
+    """
+    if channel == _RELEASE_CHANNEL:
+        return f"{_CAPSTOR_IMAGES}/{image_name}-{arch}.sqsh"
+    return f"{_CAPSTOR_IMAGES}/{channel}/{image_name}-{arch}.sqsh"
+
+
 def _build_slurm_script(
     image_name: str,
     arch: str,
+    channel: str,
     account: str,
     partition: str,
     reservation: str | None,
@@ -35,13 +53,13 @@ def _build_slurm_script(
     ghcr_actor: str,
 ) -> str:
     reservation_line = f"#SBATCH --reservation={reservation}" if reservation else ""
-    # Push to an arch-specific tag; a later merge step combines the per-arch
-    # tags into a single multi-arch manifest list under ":latest".
-    ghcr_image = f"ghcr.io/swiss-ai/{image_name}:latest-{arch}"
+    # Push to a channel- and arch-specific tag; a later merge step combines the
+    # per-arch tags into a single multi-arch manifest list under ":<channel>".
+    ghcr_image = f"ghcr.io/swiss-ai/{image_name}:{channel}-{arch}"
     return dedent(
         f"""
         #!/bin/bash
-        #SBATCH --job-name=build-{image_name}-{arch}
+        #SBATCH --job-name=build-{image_name}-{arch}-{channel}
         #SBATCH --nodes=1
         #SBATCH --ntasks=1
         #SBATCH --cpus-per-task=64
@@ -60,8 +78,8 @@ def _build_slurm_script(
         export XDG_RUNTIME_DIR="${{TMPDIR:-/tmp}}/podman-runtime-$$"
         mkdir -p "${{XDG_RUNTIME_DIR}}"
 
-        IMAGE_TAG="{image_name}-{arch}:${{SLURM_JOB_ID}}"
-        SCRATCH_SQSH="${{SCRATCH}}/{image_name}-{arch}.sqsh"
+        IMAGE_TAG="{image_name}-{arch}-{channel}:${{SLURM_JOB_ID}}"
+        SCRATCH_SQSH="${{SCRATCH}}/{image_name}-{arch}-{channel}.sqsh"
 
         cleanup() {{
             podman logout ghcr.io 2>/dev/null || true
@@ -88,6 +106,7 @@ def _build_slurm_script(
 
         echo "=== Saving to capstor ==="
         mkdir -p "$(dirname "{output_sqsh}")"
+        chmod o+rx "$(dirname "{output_sqsh}")"
         cp "${{SCRATCH_SQSH}}" "{output_sqsh}.tmp"
         mv "{output_sqsh}.tmp" "{output_sqsh}"
         chmod o+rx "{output_sqsh}"
@@ -137,7 +156,7 @@ def _arch_env(base_key: str, arch: str) -> str | None:
     return os.environ.get(f"{base_key}_{arch.upper()}")
 
 
-async def main(image_name: str, arch: str) -> int:
+async def main(image_name: str, arch: str, channel: str) -> int:
     # Shared across both clusters.
     client_id = os.environ["SML_FIRECREST_CLIENT_ID"]
     client_secret = os.environ["SML_FIRECREST_CLIENT_SECRET"]
@@ -175,9 +194,10 @@ async def main(image_name: str, arch: str) -> int:
     username = user_info["user"]["name"]
     account = user_info["group"]["name"]
 
-    # Arch-suffixed so concurrent arm64/amd64 builds don't clobber each other's
-    # uploaded build context on a shared home filesystem.
-    remote_build_dir = f"/users/{username}/.sml/image-builds/{image_name}-{arch}"
+    # Arch- and channel-suffixed so concurrent builds (arm64/amd64, main/PR)
+    # don't clobber each other's uploaded build context on a shared home
+    # filesystem.
+    remote_build_dir = f"/users/{username}/.sml/image-builds/{image_name}-{arch}-{channel}"
     remote_logs_dir = f"/users/{username}/.sml/image-builds/logs"
 
     print("Creating remote directories...")
@@ -200,11 +220,12 @@ async def main(image_name: str, arch: str) -> int:
 
     # Arch-suffixed: capstor is a shared store, so per-arch builds must not
     # write to the same path.
-    output_sqsh = f"{_CAPSTOR_IMAGES}/{image_name}-{arch}.sqsh"
+    output_sqsh = sqsh_path(image_name, arch, channel)
 
     script = _build_slurm_script(
         image_name=image_name,
         arch=arch,
+        channel=channel,
         account=account,
         partition=partition,
         reservation=reservation,
@@ -246,12 +267,16 @@ async def main(image_name: str, arch: str) -> int:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) not in (2, 3):
-        print(f"Usage: {sys.argv[0]} <image_name> [arch]", file=sys.stderr)
+    if len(sys.argv) not in (2, 3, 4):
+        print(f"Usage: {sys.argv[0]} <image_name> [arch] [channel]", file=sys.stderr)
         sys.exit(1)
     image_arg = sys.argv[1]
-    arch_arg = sys.argv[2] if len(sys.argv) == 3 else "arm64"
+    arch_arg = sys.argv[2] if len(sys.argv) >= 3 else "arm64"
+    channel_arg = sys.argv[3] if len(sys.argv) == 4 else _RELEASE_CHANNEL
     if arch_arg not in ("arm64", "amd64"):
         print(f"Unsupported arch '{arch_arg}' (expected arm64 or amd64)", file=sys.stderr)
         sys.exit(1)
-    sys.exit(asyncio.run(main(image_arg, arch_arg)))
+    if not _CHANNEL_RE.match(channel_arg):
+        print(f"Unsupported channel '{channel_arg}' (expected 'latest' or 'pr-<number>')", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(asyncio.run(main(image_arg, arch_arg, channel_arg)))

--- a/.github/scripts/cleanup_pr_images.py
+++ b/.github/scripts/cleanup_pr_images.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import asyncio
+import os
+import sys
+
+import firecrest as f7t
+from build_image import _CAPSTOR_IMAGES, _CHANNEL_RE, _RELEASE_CHANNEL
+
+
+async def _rm(client: f7t.v2.AsyncFirecrest, system_name: str, account: str, path: str) -> None:
+    print(f"Removing {path}")
+    try:
+        await client.rm(system_name=system_name, path=path, account=account, blocking=True)
+    except Exception as e:  # noqa: BLE001
+        # The directory is absent whenever the PR touched no image, which is
+        # the common case. Cleanup must never fail the workflow.
+        print(f"  Skipped: {e}")
+
+
+async def main(channel: str) -> int:
+    client_id = os.environ["SML_FIRECREST_CLIENT_ID"]
+    client_secret = os.environ["SML_FIRECREST_CLIENT_SECRET"]
+    token_uri = os.environ["SML_FIRECREST_TOKEN_URI"]
+    firecrest_url = os.environ["SML_FIRECREST_URL"]
+    system_name = os.environ["SML_SYSTEM"]
+
+    auth = f7t.ClientCredentialsAuth(client_id, client_secret, token_uri, min_token_validity=90)
+    client = f7t.v2.AsyncFirecrest(firecrest_url, authorization=auth)
+
+    user_info = await client.userinfo(system_name)
+    username = user_info["user"]["name"]
+    account = user_info["group"]["name"]
+
+    # capstor is shared across both build clusters, so one endpoint suffices.
+    await _rm(client, system_name, account, f"{_CAPSTOR_IMAGES}/{channel}")
+
+    # Build contexts are per-cluster, but home is shared with the same layout;
+    # remove whatever this endpoint can see.
+    builds_dir = f"/users/{username}/.sml/image-builds"
+    try:
+        entries = await client.list_files(system_name=system_name, path=builds_dir, account=account)
+    except Exception as e:  # noqa: BLE001
+        print(f"Could not list {builds_dir}: {e}")
+        return 0
+
+    for entry in entries:
+        name = entry.get("name", "")
+        if name.endswith(f"-{channel}"):
+            await _rm(client, system_name, account, f"{builds_dir}/{name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <channel>", file=sys.stderr)
+        sys.exit(1)
+    channel_arg = sys.argv[1]
+    if not _CHANNEL_RE.match(channel_arg) or channel_arg == _RELEASE_CHANNEL:
+        # Guard hard: this script deletes directories by path.
+        print(f"Refusing to clean up channel '{channel_arg}' (expected 'pr-<number>')", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(asyncio.run(main(channel_arg)))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,25 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       images: ${{ steps.detect.outputs.images }}
+      channel: ${{ steps.channel.outputs.channel }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Resolve release channel
+        id: channel
+        run: |
+          # PR builds publish to a per-PR pre-release channel so they can never
+          # overwrite what main published. Merging to main republishes under
+          # ":latest". build_image.py rejects any other channel value.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANNEL="pr-${{ github.event.pull_request.number }}"
+          else
+            CHANNEL="latest"
+          fi
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "Release channel: $CHANNEL"
 
       - name: Detect changed image directories
         id: detect
@@ -77,8 +92,8 @@ jobs:
       matrix:
         image: ${{ fromJson(needs.detect-changes.outputs.images) }}
         # Each arch is built natively on its own cluster, reached via a
-        # different FireCREST endpoint, and pushed to a :latest-<arch> tag.
-        # The merge-manifests job combines them into a multi-arch :latest.
+        # different FireCREST endpoint, and pushed to a :<channel>-<arch> tag.
+        # The merge-manifests job combines them into a multi-arch :<channel>.
         arch: [arm64, amd64]
       fail-fast: false
     env:
@@ -97,6 +112,10 @@ jobs:
       SML_PARTITION_AMD64: ${{ vars.SML_PARTITION_AMD64 }}
       GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GHCR_ACTOR: ${{ github.actor }}
+      # The channel is part of the cache key: a PR build only proves the
+      # pr-<N> artifacts exist. Without it, merging an already-built PR would
+      # hit the cache on main, skip the build, and never publish ":latest".
+      CHANNEL: ${{ needs.detect-changes.outputs.channel }}
     steps:
       - uses: actions/checkout@v5
       - name: Restore build cache
@@ -104,14 +123,14 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build-sentinel
-          key: build-${{ matrix.image }}-${{ matrix.arch }}-${{ hashFiles(format('images/{0}/**', matrix.image)) }}
+          key: build-${{ env.CHANNEL }}-${{ matrix.image }}-${{ matrix.arch }}-${{ hashFiles(format('images/{0}/**', matrix.image)) }}
       - uses: ./.github/actions/setup
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           python-version: "3.12"
       - name: Build image and save sqsh
         if: steps.cache.outputs.cache-hit != 'true'
-        run: python .github/scripts/build_image.py "${{ matrix.image }}" "${{ matrix.arch }}"
+        run: python .github/scripts/build_image.py "${{ matrix.image }}" "${{ matrix.arch }}" "${{ env.CHANNEL }}"
         timeout-minutes: 300
       - name: Save build cache
         if: steps.cache.outputs.cache-hit != 'true'
@@ -120,10 +139,10 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: .build-sentinel
-          key: build-${{ matrix.image }}-${{ matrix.arch }}-${{ hashFiles(format('images/{0}/**', matrix.image)) }}
+          key: build-${{ env.CHANNEL }}-${{ matrix.image }}-${{ matrix.arch }}-${{ hashFiles(format('images/{0}/**', matrix.image)) }}
 
   merge-manifests:
-    name: Merge multi-arch manifest ${{ matrix.image }}
+    name: Merge multi-arch manifest ${{ matrix.image }} (${{ needs.detect-changes.outputs.channel }})
     needs: [detect-changes, build]
     # Only if every arch build succeeded — a partial set would yield a
     # single-arch manifest.
@@ -142,17 +161,19 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create and push multi-arch :latest
+      - name: Create and push multi-arch manifest
         env:
           IMAGE: ghcr.io/swiss-ai/${{ matrix.image }}
+          CHANNEL: ${{ needs.detect-changes.outputs.channel }}
         run: |
-          docker buildx imagetools create -t "${IMAGE}:latest" \
-            "${IMAGE}:latest-arm64" \
-            "${IMAGE}:latest-amd64"
+          docker buildx imagetools create -t "${IMAGE}:${CHANNEL}" \
+            "${IMAGE}:${CHANNEL}-arm64" \
+            "${IMAGE}:${CHANNEL}-amd64"
       - name: Inspect
         env:
           IMAGE: ghcr.io/swiss-ai/${{ matrix.image }}
-        run: docker buildx imagetools inspect "${IMAGE}:latest"
+          CHANNEL: ${{ needs.detect-changes.outputs.channel }}
+        run: docker buildx imagetools inspect "${IMAGE}:${CHANNEL}"
 
   test-lightweight:
     name: Integration Tests (lightweight)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,20 @@ jobs:
           # PR builds publish to a per-PR pre-release channel so they can never
           # overwrite what main published. Merging to main republishes under
           # ":latest". build_image.py rejects any other channel value.
+          #
+          # ":latest" means "built from main" — gate on the ref, not the event.
+          # A workflow_dispatch runs against whatever branch it was dispatched
+          # from, and with an empty `image` input it rebuilds every image, so
+          # an ungated dispatch could republish all of :latest from unmerged
+          # code. Refuse rather than publish.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANNEL="pr-${{ github.event.pull_request.number }}"
-          else
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
             CHANNEL="latest"
+          else
+            echo "Refusing to publish images from ${{ github.ref }}." >&2
+            echo "Open a pull request to build under a pr-<number> channel." >&2
+            exit 1
           fi
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "Release channel: $CHANNEL"

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -1,0 +1,55 @@
+name: Cleanup PR Images
+
+# PR builds publish pre-release artifacts under a pr-<number> channel: GHCR
+# tags (pr-N, pr-N-arm64, pr-N-amd64) and a capstor sqsh directory. Once the PR
+# is closed — merged or not — nothing references them, so remove them here.
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: Delete pr-${{ github.event.pull_request.number }} artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      CHANNEL: pr-${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Delete GHCR tags
+        # Deleting an org-owned package version needs admin on the package.
+        # Provide GHCR_DELETE_TOKEN (a PAT with delete:packages) if the default
+        # token is not enough; never fail the workflow over leftover tags.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_DELETE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          # Exact tag match only: a prefix match on "pr-4" would also delete
+          # "pr-42". Each channel owns exactly these three tags.
+          FILTER=".[] | select(.metadata.container.tags | any(. == \"${CHANNEL}\" or . == \"${CHANNEL}-arm64\" or . == \"${CHANNEL}-amd64\")) | .id"
+          for image in $(ls images/); do
+            echo "== $image"
+            versions=$(gh api --paginate \
+              "/orgs/swiss-ai/packages/container/${image}/versions" \
+              --jq "$FILTER") || continue
+            for id in $versions; do
+              echo "  deleting version $id"
+              gh api -X DELETE "/orgs/swiss-ai/packages/container/${image}/versions/${id}" || true
+            done
+          done
+
+      - uses: ./.github/actions/setup
+        with:
+          python-version: "3.12"
+
+      - name: Delete capstor sqsh directory and build contexts
+        continue-on-error: true
+        env:
+          SML_FIRECREST_CLIENT_ID: ${{ secrets.SML_FIRECREST_CLIENT_ID }}
+          SML_FIRECREST_CLIENT_SECRET: ${{ secrets.SML_FIRECREST_CLIENT_SECRET }}
+          SML_FIRECREST_TOKEN_URI: ${{ secrets.SML_FIRECREST_TOKEN_URI }}
+          SML_FIRECREST_URL: ${{ vars.SML_FIRECREST_URL }}
+          SML_SYSTEM: ${{ vars.SML_SYSTEM }}
+        run: python .github/scripts/cleanup_pr_images.py "${CHANNEL}"

--- a/src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml
+++ b/src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml
@@ -1,4 +1,4 @@
-image = "/capstor/store/cscs/swissai/infra01/container-images/ci/vllm_apertus_1.5-arm64.sqsh"
+image = "/capstor/store/cscs/swissai/infra01/container-images/ci/vllm_apertus_1.5-{arch}.sqsh"
 
 mounts = [
   "/capstor/store/cscs/swissai/infra01/opentela-share:/opentelabin",

--- a/src/swiss_ai_model_launch/launchers/framework.py
+++ b/src/swiss_ai_model_launch/launchers/framework.py
@@ -433,11 +433,14 @@ def _render_arch_detection(launch_args: LaunchArgs) -> str:
         '    echo "Running on ARM64 (aarch64)"',
         "    export SP_NCCL_SO_PATH=/usr/lib/aarch64-linux-gnu/",
         f"    export OPENTELA_BIN=/opentelabin/{opentela_bin_channel}/otela-arm64",
+        # Consumed by the env-file {arch} substitution below.
+        "    SML_ARCH=arm64",
     ]
     x86_lines = [
         '    echo "Running on x86_64"',
         "    export SP_NCCL_SO_PATH=/usr/lib/x86_64-linux-gnu/",
         f"    export OPENTELA_BIN=/opentelabin/{opentela_bin_channel}/otela-amd64",
+        "    SML_ARCH=amd64",
     ]
     if needs_metrics_bin:
         arm_lines.append(f'    metrics_agent_bin="{base}-arm64"')
@@ -455,6 +458,39 @@ def _render_arch_detection(launch_args: LaunchArgs) -> str:
         f'elif [[ "$ARCH" == "x86_64" ]]; then\n{x86_block}\n'
         "else\n"
         '    echo "Unknown architecture: $ARCH" >&2\n'
+        "    exit 1\n"
+        "fi"
+    )
+
+
+def _render_env_file_resolution(launch_args: LaunchArgs) -> str:
+    """Resolve an ``{arch}`` placeholder in the env toml's image path.
+
+    CI builds each image natively per arch and writes ``<image>-arm64.sqsh`` /
+    ``<image>-amd64.sqsh``. A single env toml has to serve both clusters, and
+    the launcher never knows the target arch — it is only known on the node,
+    from ``uname -m``. So substitute here, on the batch host, and hand srun the
+    resolved copy.
+
+    Env files with no placeholder are passed through untouched, so a pinned
+    path (``...-arm64.sqsh``) keeps working.
+    """
+    env = launch_args.environment
+    return (
+        f'SML_ENV_FILE="{env}"\n'
+        'if grep -q "{arch}" "$SML_ENV_FILE"; then\n'
+        '    SML_RESOLVED_ENV="env_resolved_${SLURM_JOB_ID}_${SML_ARCH}.toml"\n'
+        '    sed "s|{arch}|${SML_ARCH}|g" "$SML_ENV_FILE" > "$SML_RESOLVED_ENV"\n'
+        '    SML_ENV_FILE="$SML_RESOLVED_ENV"\n'
+        '    echo "Resolved env file for ${SML_ARCH}: $SML_ENV_FILE"\n'
+        "fi\n"
+        "\n"
+        "# A missing image is otherwise reported by pyxis as an opaque failure\n"
+        "# deep inside srun; fail here with the path that was actually wanted.\n"
+        'SML_IMAGE=$(sed -n \'s|^ *image *= *"\\(/[^"]*\\)".*|\\1|p\' "$SML_ENV_FILE" | head -1)\n'
+        'if [[ -n "$SML_IMAGE" && ! -e "$SML_IMAGE" ]]; then\n'
+        '    echo "Container image not found: $SML_IMAGE" >&2\n'
+        '    echo "  (from env file $SML_ENV_FILE, arch ${SML_ARCH})" >&2\n'
         "    exit 1\n"
         "fi"
     )
@@ -494,7 +530,6 @@ def _render_replica_head_ip_discovery(replicas: int, nodes_per_replica: int) -> 
 def _render_replica_launches(launch_args: LaunchArgs) -> str:
     topology = launch_args.topology
     npr = topology.nodes_per_replica
-    env = launch_args.environment
 
     def srun_call(node_index: int, script: str, args: str, comment: str, log_base: str) -> str:
         return (
@@ -506,7 +541,7 @@ def _render_replica_launches(launch_args: LaunchArgs) -> str:
             # pyxis container. Attached per-srun rather than via the env toml's
             # static mount list, which is being narrowed and read-only-ed.
             f'    --container-mounts="$RANKS_DIR:$RANKS_DIR" \\\n'
-            f'    --environment="{env}" \\\n'
+            '    --environment="${SML_ENV_FILE}" \\\n'
             # Per-replica stdout/stderr (the batch script's own log.out/log.err
             # only carries the master's orchestration output).
             f'    --output="logs/${{SLURM_JOB_ID}}/{log_base}.out" \\\n'
@@ -694,7 +729,7 @@ def _render_router_launch(launch_args: LaunchArgs) -> str:
         'srun --nodes=1 --ntasks=1 --nodelist="$router_host_node" \\\n'
         "    --container-writable \\\n"
         '    --container-mounts="$RANKS_DIR:$RANKS_DIR" \\\n'
-        f'    --environment="{launch_args.environment}" \\\n'
+        '    --environment="${SML_ENV_FILE}" \\\n'
         "    --overlap \\\n"
         '    --output="logs/${SLURM_JOB_ID}/router.out" \\\n'
         '    --error="logs/${SLURM_JOB_ID}/router.err" \\\n'
@@ -780,6 +815,7 @@ def render_master(launch_args: LaunchArgs) -> str:
         sections.append(telemetry)
 
     sections.append(_render_arch_detection(launch_args))
+    sections.append(_render_env_file_resolution(launch_args))
     sections.append(_render_node_mapping())
 
     topology = launch_args.topology


### PR DESCRIPTION
## Problem

Docker images built in a PR were published to `ghcr.io/swiss-ai/<image>:latest` and to the shared capstor path `container-images/ci/<image>-<arch>.sqsh`, overwriting whatever main had published.

The sqsh path is the more serious half: the env TOMLs point SLURM launches straight at it, so an open PR could swap the image out from under a launch running off main.

## 1. PR builds get their own channel

A **release channel** is threaded from `ci.yml` through `build_image.py`: `latest` for main, `pr-<number>` for pull requests.

| Artifact | Before (any build) | After (PR #42) |
|---|---|---|
| GHCR per-arch | `:latest-arm64` | `:pr-42-arm64` |
| GHCR manifest | `:latest` | `:pr-42` |
| capstor sqsh | `ci/<image>-arm64.sqsh` | `ci/pr-42/<image>-arm64.sqsh` |

PR builds still publish, so they can be pulled and tested — they just no longer overwrite `latest`. Merging to main rebuilds and republishes under `:latest`.

Two scratch paths that PR and main builds shared are now channel-scoped too: the SLURM build context under `~/.sml/image-builds/` and the intermediate `$SCRATCH/*.sqsh`.

### The build cache was the trap

The key was `build-<image>-<arch>-<hashFiles>`, with no channel in it. Changing only the tags would mean a PR that built an image and then merged unchanged hits that cache on main, skips the build, and **never pushes `:latest`** — the same bug, one layer down. The key now leads with the channel.

## 2. `:latest` now means "built from main"

`workflow_dispatch` resolved to the `latest` channel from **any** branch, so a manual dispatch from a feature branch could publish unmerged code as `:latest` — and since its `image` input defaults to empty, it could republish *every* image at once. The channel step now gates on `github.ref` and refuses to publish from anything but `refs/heads/main`.

This removes the ability to dispatch a test build from a feature branch. PR builds cover that case via `pr-<N>`.

## 3. Env TOMLs resolve `{arch}` at launch

Since #157 CI writes `<image>-arm64.sqsh` / `<image>-amd64.sqsh`, but four of the five env TOMLs read the un-suffixed `<image>.sqsh`.

**Nothing was broken yet**, and it's worth being precise about why: `detect-changes` builds only *changed* image dirs, and `k6`, `sglang_cuda13`, `vllm_cuda13`, `sglang_0.5.10_rocm` haven't changed since the arch split. The un-suffixed files on capstor (May 4, Jun 8) are their last real builds — exactly what the TOMLs read. The trap springs on the *next* edit to any of those dirs: CI writes arch-suffixed artifacts, the TOML keeps reading the stale un-suffixed file, and the change silently never reaches a launch.

A single env TOML has to serve both clusters, and the launcher **never knows the target arch** — it is resolved on the node from `uname -m` (`_render_arch_detection`). So the batch script now substitutes an `{arch}` placeholder into a per-job copy of the env file and hands `srun` the resolved path:

```
image = ".../vllm_apertus_1.5-{arch}.sqsh"   →   -arm64.sqsh on Grace, -amd64.sqsh on x86
```

TOMLs with no placeholder pass through untouched, so pinned paths keep working. A missing image now fails with the path that was actually wanted, instead of an opaque pyxis error deep inside `srun`.

**Only `vllm_apertus_1.5.toml` is switched over here** — it is the one image with both arch artifacts on capstor today. See the rollout note below.

## Cleanup

`cleanup-pr-images.yml` fires on `pull_request: closed` and drops the three `pr-<N>` GHCR tags, the capstor directory, and the build contexts.

Deleting an *org*-owned package version may need admin on the package, which `GITHUB_TOKEN` may not have. The step reads an optional `GHCR_DELETE_TOKEN` secret (a PAT with `delete:packages`) and falls back to `GITHUB_TOKEN`, with `continue-on-error` so leftover tags never fail a merge. **Watch the first close of a PR that actually built an image — if the delete 403s, add the PAT.**

## Rollout, in order

The remaining TOMLs cannot be switched to `{arch}` until their arch-suffixed artifacts exist, and merging this PR does not create them (it changes no `images/` dir, so nothing rebuilds):

1. Merge this PR.
2. Run `workflow_dispatch` on **main** with an empty `image` input to rebuild all five images, producing `<image>-arm64.sqsh` / `<image>-amd64.sqsh`.
3. Follow-up PR: switch `vllm.toml`, `sglang.toml`, `sglang_rocm.toml`, and the k6 loadtest default to `{arch}`.

Doing step 3 before step 2 would point every launch at a file that does not exist.

## Testing

`ruff check` / `ruff format` / `mypy src` clean; 378 unit tests pass; the generated shell block is `shellcheck` clean.

Existing tests don't execute the generated shell, so I ran the rendered block under bash directly:

- templated + `SML_ARCH=arm64` → resolves to `-arm64.sqsh`;
- templated + `SML_ARCH=amd64` → resolves to `-amd64.sqsh`;
- no placeholder → file passed through untouched, exit 0;
- placeholder resolving to a nonexistent image → exits 1 with the wanted path.

Also verified the batch script runs under `set -euo pipefail`, so a failed `sed` aborts the job rather than launching a wrong image, and that `environment` is an absolute remote path by render time, so the resolved copy lands in the writable working dir.

Channel guard rejects `../../etc`, `pr-42; rm -rf /`, `main`, and empty. The deletion `jq` filter matches `pr-4` / `pr-4-arm64` and leaves `pr-42` alone — the first draft used `startswith`, which would have deleted PR #42's image when PR #4 closed.

Not exercised against real infrastructure: the FireCREST `rm` calls, the GHCR deletion API, and an actual two-cluster launch through the `{arch}` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yyiEE7oEK4HbuWEh6iSfA