### PR TITLE
Stop the live display querying widgets after teardown

### DIFF
--- a/src/swiss_ai_model_launch/cli/display/live.py
+++ b/src/swiss_ai_model_launch/cli/display/live.py
@@ -376,6 +376,12 @@ class _SMLApp(App[bool]):
         self.set_interval(0.5, self._tick)
         self.run_worker(self._work, exclusive=True)
 
+    def on_unmount(self) -> None:
+        # DisplayState outlives the app: the monitor keeps updating it while the
+        # app tears down. Leaving _refresh_all wired means a late update queries
+        # widgets that no longer exist.
+        self._state._on_change = lambda: None
+
     def on_tabbed_content_tab_activated(self, event: TabbedContent.TabActivated) -> None:
         # Only the outer (source) tabs change which source the monitor fetches;
         # ignore the inner stdout/stderr switches.
@@ -584,6 +590,10 @@ class _SMLApp(App[bool]):
         return table
 
     def _tick(self) -> None:
+        # The interval can fire once more while the app is shutting down, after
+        # the widgets are gone.
+        if not self.is_running:
+            return
         # Drive the blinking HEALTHY heart and refresh both panels that show it.
         self._blink_on = not self._blink_on
         self.query_one(f"#{_STATUS_LABEL_ID}", Label).update(self._render_status())
@@ -625,6 +635,10 @@ class _SMLApp(App[bool]):
             area.scroll_to(x=previous_offset.x, y=previous_offset.y, animate=False)
 
     def _refresh_all(self) -> None:
+        # A state update can land between the widgets being torn down and
+        # on_unmount running, which is where _on_change is dropped.
+        if not self.is_running:
+            return
         self.query_one(f"#{_STATUS_LABEL_ID}", Label).update(self._render_status())
         self._refresh_chain()
         self._refresh_replicas()

--- a/tests/unit/test_live_tabs.py
+++ b/tests/unit/test_live_tabs.py
@@ -109,3 +109,17 @@ async def test_log_pane_unchanged_text_is_not_reloaded() -> None:
         state.set_source_log("Master", "\n".join(f"line {i}" for i in range(200)), "")
         await pilot.pause()
         assert out.scroll_offset.y == 0
+
+
+async def test_state_update_after_app_exits_is_ignored() -> None:
+    """DisplayState outlives the app; the monitor keeps updating it during teardown.
+
+    A late update must not query widgets that are already gone.
+    """
+    state = DisplayState()
+    app = _SMLApp(state, asyncio.sleep(3600))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+    state.update(job_id=42)  # would raise NoMatches if _refresh_all were still wired
+    app._tick()  # the 0.5s interval can fire once more during shutdown


### PR DESCRIPTION
## Symptom

```
FAILED tests/unit/test_terminal_chord.py::test_chord_opens_terminal_for_typed_node
  textual.css.query.NoMatches: No nodes match '#status-label' on Screen(id='_default')
```

The test never queries `#status-label`. The exception is raised from inside the app.

## Cause

`_SMLApp.on_mount` does two things that outlive the widgets:

- wires `state._on_change = self._refresh_all`
- starts a 0.5s `self._tick` interval

Both call `query_one("#status-label")`, and neither is ever unwired. `DisplayState` outlives the app — the `_work` worker keeps updating it while the app tears down — so a late `state.update()` or one final timer tick queries a screen whose children are gone.

The test finishes in well under 0.5s, so the window is narrow, which is why this reads as a flake. It reproduces reliably when the callbacks are driven directly after teardown.

**This is not test-only.** In production the monitor updates `DisplayState` continuously; quitting the TUI while an update is in flight hits the same path.

## Fix

- `on_unmount` drops the `_on_change` callback.
- `_tick` and `_refresh_all` early-return unless `is_running` — an update can still land between the widgets being removed and `on_unmount` running, so unwiring alone leaves a gap.

## Testing

Added `test_state_update_after_app_exits_is_ignored`, which drives both paths after `run_test` exits. Verified it is not vacuous: with the fix stashed it fails with `NoMatches`; with the fix applied it passes.

379 unit tests pass; `ruff check`, `ruff format --check`, and `mypy src` clean.

Unrelated to #174 — this branch is cut from `main` and touches no CI or image code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yyiEE7oEK4HbuWEh6iSfA