### PR TITLE
Keep the resolved env file path absolute and out of the package dir

### DIFF
--- a/src/swiss_ai_model_launch/launchers/framework.py
+++ b/src/swiss_ai_model_launch/launchers/framework.py
@@ -479,7 +479,14 @@ def _render_env_file_resolution(launch_args: LaunchArgs) -> str:
     return (
         f'SML_ENV_FILE="{env}"\n'
         'if grep -q "{arch}" "$SML_ENV_FILE"; then\n'
-        '    SML_RESOLVED_ENV="env_resolved_${SLURM_JOB_ID}_${SML_ARCH}.toml"\n'
+        # Absolute, and in the job's working dir. Two constraints:
+        #  - pyxis treats an --environment value with no "/" in it as an EDF
+        #    *name*: it appends ".toml" and searches ~/.edf and the site EDF
+        #    dir, never the working directory.
+        #  - the source toml may be the read-only packaged asset (the local
+        #    SLURM launcher passes it straight through), so don't write beside
+        #    it. $PWD already holds the job's logs/ tree.
+        '    SML_RESOLVED_ENV="${PWD}/env_resolved_${SLURM_JOB_ID}_${SML_ARCH}.toml"\n'
         '    sed "s|{arch}|${SML_ARCH}|g" "$SML_ENV_FILE" > "$SML_RESOLVED_ENV"\n'
         '    SML_ENV_FILE="$SML_RESOLVED_ENV"\n'
         '    echo "Resolved env file for ${SML_ARCH}: $SML_ENV_FILE"\n'

--- a/tests/unit/test_env_arch_resolution.py
+++ b/tests/unit/test_env_arch_resolution.py
@@ -1,0 +1,101 @@
+# ruff: noqa: S603, S607  # subprocess invocations against controlled paths/binaries
+"""The {arch} placeholder in an env toml's image path, resolved on the batch node.
+
+These run the generated shell for real: the bug this guards against (a relative
+resolved path, which pyxis reinterprets as an EDF *name* and suffixes with
+".toml") is invisible to any test that only inspects the rendered string.
+"""
+
+import subprocess
+from pathlib import Path
+
+from swiss_ai_model_launch.launchers.framework import _render_env_file_resolution
+from swiss_ai_model_launch.launchers.launch_args import LaunchArgs
+
+_IMAGE_DIR = "imgs"
+
+
+def _args(environment: str) -> LaunchArgs:
+    return LaunchArgs(
+        job_name="j",
+        served_model_name="vendor/model-abc1",
+        account="proj01",
+        partition="normal",
+        environment=environment,
+        framework="vllm",
+    )
+
+
+def _run(env_file: Path, arch: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    block = _render_env_file_resolution(_args(str(env_file)))
+    script = f'set -euo pipefail\nSML_ARCH={arch}\n{block}\necho "RESOLVED=$SML_ENV_FILE"\n'
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=cwd,  # deliberately not the env file's directory
+        env={"SLURM_JOB_ID": "2724141", "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+
+
+def _resolved(proc: subprocess.CompletedProcess[str]) -> str:
+    line = next(ln for ln in proc.stdout.splitlines() if ln.startswith("RESOLVED="))
+    return line.removeprefix("RESOLVED=")
+
+
+def _write_env(tmp_path: Path, image: str) -> Path:
+    work = tmp_path / "work"
+    work.mkdir()
+    env_file = work / "env_vllm_abc.toml"
+    env_file.write_text(f'image = "{image}"\n')
+    return env_file
+
+
+def test_placeholder_resolves_to_absolute_path(tmp_path: Path) -> None:
+    """pyxis needs a path, not a bare name: a value with no "/" becomes an EDF name."""
+    (tmp_path / _IMAGE_DIR).mkdir()
+    (tmp_path / _IMAGE_DIR / "vllm-arm64.sqsh").touch()
+    env_file = _write_env(tmp_path, f"{tmp_path}/{_IMAGE_DIR}/vllm-{{arch}}.sqsh")
+
+    proc = _run(env_file, "arm64", cwd=tmp_path)
+
+    assert proc.returncode == 0, proc.stderr
+    resolved = Path(_resolved(proc))
+    assert resolved.is_absolute()
+    assert resolved.read_text() == f'image = "{tmp_path}/{_IMAGE_DIR}/vllm-arm64.sqsh"\n'
+    # Lands in the job's working dir, not beside the source toml — which for the
+    # local SLURM launcher is the read-only packaged asset directory.
+    assert resolved.parent == tmp_path
+    assert not list(env_file.parent.glob("env_resolved_*"))
+
+
+def test_placeholder_resolves_per_arch(tmp_path: Path) -> None:
+    (tmp_path / _IMAGE_DIR).mkdir()
+    (tmp_path / _IMAGE_DIR / "vllm-amd64.sqsh").touch()
+    env_file = _write_env(tmp_path, f"{tmp_path}/{_IMAGE_DIR}/vllm-{{arch}}.sqsh")
+
+    proc = _run(env_file, "amd64", cwd=tmp_path)
+
+    assert proc.returncode == 0, proc.stderr
+    assert "vllm-amd64.sqsh" in Path(_resolved(proc)).read_text()
+
+
+def test_pinned_path_is_passed_through_untouched(tmp_path: Path) -> None:
+    (tmp_path / _IMAGE_DIR).mkdir()
+    (tmp_path / _IMAGE_DIR / "vllm-arm64.sqsh").touch()
+    env_file = _write_env(tmp_path, f"{tmp_path}/{_IMAGE_DIR}/vllm-arm64.sqsh")
+
+    proc = _run(env_file, "arm64", cwd=tmp_path)
+
+    assert proc.returncode == 0, proc.stderr
+    assert _resolved(proc) == str(env_file)
+
+
+def test_missing_image_fails_with_the_wanted_path(tmp_path: Path) -> None:
+    """Otherwise pyxis reports it as an opaque failure deep inside srun."""
+    env_file = _write_env(tmp_path, f"{tmp_path}/{_IMAGE_DIR}/absent-{{arch}}.sqsh")
+
+    proc = _run(env_file, "arm64", cwd=tmp_path)
+
+    assert proc.returncode == 1
+    assert f"{tmp_path}/{_IMAGE_DIR}/absent-arm64.sqsh" in proc.stderr


### PR DESCRIPTION
## Symptom

Regression on `main` (introduced by #174). A real launch fails at `srun`:

```
srun: error: pyxis: --environment: failed to find a readable environment file
  'env_resolved_2724141_arm64.toml.toml' in search path
  '/users/ahadinia/.edf:/capstor/store/cscs/cscs/public/containers/edf/gh200' on 'nid006110'
srun: error: pyxis: failed to parse environment definition file
```

Note the doubled extension: `...arm64.toml.toml`.

## Cause

pyxis treats an `--environment` value **containing no `/`** as an EDF *name*, not a path: it appends `.toml` and searches `~/.edf` and the site EDF directory, never the job's working directory.

`_upload_env_file` returns an absolute path, so the pre-existing code was fine. The `{arch}` substitution added in #174 wrote its resolved copy to a bare filename, which pyxis then reinterpreted.

**Impact:** any launch whose env toml contains an `{arch}` placeholder — today that is `vllm_apertus_1.5.toml` — fails at `srun`. Env files with a pinned path skip the substitution and are unaffected.

## Fix

Write the resolved copy to `"${PWD}/env_resolved_${SLURM_JOB_ID}_${SML_ARCH}.toml"`.

Two constraints have to hold at once, and the obvious fix only satisfies one:

- **Absolute**, or pyxis reinterprets it as an EDF name (the bug above).
- **Not beside the source toml.** Deriving the directory from `dirname "$SML_ENV_FILE"` is absolute and passes pyxis, but the local SLURM launcher hands sbatch the *packaged asset path* directly (`files("swiss_ai_model_launch.assets.envs")`) with no upload. Writing there pollutes the source tree, and on an installed read-only copy it fails outright. I hit this: a stray `src/swiss_ai_model_launch/assets/envs/env_resolved_2724256_arm64.toml` appeared during testing.

`$PWD` satisfies both. It is the job's working directory, which the script already depends on being writable and shared — it writes `logs/${SLURM_JOB_ID}/...` relative to it.

## Testing

`tests/unit/test_env_arch_resolution.py` **executes the generated shell** rather than inspecting the rendered string — the string looked entirely correct, which is exactly why this reached `main`. Four cases: absolute-path resolution, per-arch substitution, pinned-path passthrough, and the missing-image error.

Verified not vacuous against **both** wrong implementations:

| `framework.py` variant | Result |
|---|---|
| `main`'s bare filename | 2 tests fail |
| `dirname` (absolute, wrong dir) | 1 test fails |
| this branch (`$PWD`) | 4 pass |

383 unit tests pass; `ruff check`, `ruff format --check`, `mypy src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yyiEE7oEK4HbuWEh6iSfA