### PR TITLE
Add Apertus Pre-release Launch Commands

### DIFF
--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-Prerelease-2607-no-think.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-Prerelease-2607-no-think.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+sml advanced \
+  --tui \
+  --partition normal \
+  --framework vllm \
+  --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
+  --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-70B-Prerelease-2607 \
+    --served-model-name apertus-ai/Apertus-v1.5-70B-Prerelease-2607-nothink \
+    --tensor-parallel-size 4 \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --trust-remote-code \
+    --trust-request-chat-template \
+    --max-model-len 262144 \
+    --gpu-memory-utilization 0.8 \
+    --skip-mm-profiling \
+    --enable-auto-tool-choice \
+    --tool-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_tool_parser.py \
+    --tool-call-parser apertus \
+    --chat-template /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_chat_template.jinja \
+    --default-chat-template-kwargs.enable_thinking false"

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-Prerelease-2607-think.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-Prerelease-2607-think.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+sml advanced \
+  --tui \
+  --partition normal \
+  --framework vllm \
+  --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
+  --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-70B-Prerelease-2607 \
+    --served-model-name apertus-ai/Apertus-v1.5-70B-Prerelease-2607-think \
+    --tensor-parallel-size 4 \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --trust-remote-code \
+    --trust-request-chat-template \
+    --max-model-len 262144 \
+    --gpu-memory-utilization 0.8 \
+    --skip-mm-profiling \
+    --enable-auto-tool-choice \
+    --tool-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_tool_parser.py \
+    --tool-call-parser apertus \
+    --chat-template /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_chat_template.jinja \
+    --reasoning-parser apertus \
+    --reasoning-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_reasoning_parser.py \
+    --default-chat-template-kwargs.enable_thinking true"

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-Prerelease-2607-no-think.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-Prerelease-2607-no-think.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+sml advanced \
+  --tui \
+  --partition normal \
+  --framework vllm \
+  --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
+  --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-8B-Prerelease-2607 \
+    --served-model-name apertus-ai/Apertus-v1.5-8B-Prerelease-2607-nothink \
+    --tensor-parallel-size 4 \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --trust-remote-code \
+    --trust-request-chat-template \
+    --max-model-len 262144 \
+    --gpu-memory-utilization 0.8 \
+    --skip-mm-profiling \
+    --enable-auto-tool-choice \
+    --tool-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_tool_parser.py \
+    --tool-call-parser apertus \
+    --chat-template /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_chat_template.jinja \
+    --default-chat-template-kwargs.enable_thinking false"

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-Prerelease-2607-think.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-Prerelease-2607-think.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+sml advanced \
+  --tui \
+  --partition normal \
+  --framework vllm \
+  --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
+  --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-8B-Prerelease-2607 \
+    --served-model-name apertus-ai/Apertus-v1.5-8B-Prerelease-2607-think \
+    --tensor-parallel-size 4 \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --trust-remote-code \
+    --trust-request-chat-template \
+    --max-model-len 262144 \
+    --gpu-memory-utilization 0.6 \
+    --skip-mm-profiling \
+    --enable-auto-tool-choice \
+    --tool-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_tool_parser.py \
+    --tool-call-parser apertus \
+    --chat-template /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_chat_template.jinja \
+    --reasoning-parser apertus \
+    --reasoning-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_reasoning_parser.py \
+    --default-chat-template-kwargs.enable_thinking true"


### PR DESCRIPTION
Adds launch commands for the Apertus v1.5 pre-release (2607) checkpoints:

- `Apertus-v1.5-8B-Prerelease-2607` (think / no-think)
- `Apertus-v1.5-70B-Prerelease-2607` (think / no-think)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3v61EuUQAk7Ws9ZmyMGQM