### PR TITLE
Update Apertus v1.5 RC Launch Scripts

### DIFF
--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607-deliberation.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607-deliberation.sh
@@ -4,10 +4,11 @@ sml advanced \
   --partition normal \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
-  --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-8B-RC-2607 \
-    --served-model-name apertus-ai/Apertus-v1.5-8B-RC-2607-think \
-    --skip-mm-profiling \
+  --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-70B-RC-2607 \
+    --served-model-name apertus-ai/Apertus-v1.5-70B-RC-2607-deliberation \
+    --tensor-parallel-size 4 \
     --trust-remote-code \
+    --skip-mm-profiling \
     --max-model-len 262144 \
     --enable-auto-tool-choice \
     --tool-call-parser apertus \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607-deliberation.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607-deliberation.sh
@@ -3,11 +3,13 @@ sml advanced \
   --tui \
   --partition normal \
   --framework vllm \
+  --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-70B-RC-2607 \
-    --served-model-name apertus-ai/Apertus-v1.5-70B-RC-2607-deliberation \
+    --served-model-name apertus-ai/Apertus-v1.5-70B-RC-deliberation \
     --tensor-parallel-size 4 \
     --trust-remote-code \
+    --gpu-memory-utilization 0.8 \
     --skip-mm-profiling \
     --max-model-len 262144 \
     --enable-auto-tool-choice \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607.sh
@@ -5,14 +5,12 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-70B-RC-2607 \
-    --served-model-name apertus-ai/Apertus-v1.5-70B-RC-2607-think \
+    --served-model-name apertus-ai/Apertus-v1.5-70B-RC-2607 \
     --tensor-parallel-size 4 \
-    --trust-remote-code \
     --skip-mm-profiling \
+    --trust-remote-code \
     --max-model-len 262144 \
     --enable-auto-tool-choice \
     --tool-call-parser apertus \
     --tool-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_tool_parser.py \
-    --reasoning-parser apertus \
-    --reasoning-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_reasoning_parser.py \
-    --default-chat-template-kwargs.enable_thinking true"
+    --default-chat-template-kwargs.enable_thinking false"

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607.sh
@@ -3,12 +3,14 @@ sml advanced \
   --tui \
   --partition normal \
   --framework vllm \
+  --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-70B-RC-2607 \
-    --served-model-name apertus-ai/Apertus-v1.5-70B-RC-2607 \
+    --served-model-name apertus-ai/Apertus-v1.5-70B-RC \
     --tensor-parallel-size 4 \
     --skip-mm-profiling \
     --trust-remote-code \
+    --gpu-memory-utilization 0.8 \
     --max-model-len 262144 \
     --enable-auto-tool-choice \
     --tool-call-parser apertus \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607-deliberation.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607-deliberation.sh
@@ -4,13 +4,14 @@ sml advanced \
   --partition normal \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
-  --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-70B-RC-2607 \
-    --served-model-name apertus-ai/Apertus-v1.5-70B-RC-2607-nothink \
-    --tensor-parallel-size 4 \
+  --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-8B-RC-2607 \
+    --served-model-name apertus-ai/Apertus-v1.5-8B-RC-2607-deliberation \
     --skip-mm-profiling \
     --trust-remote-code \
     --max-model-len 262144 \
     --enable-auto-tool-choice \
     --tool-call-parser apertus \
     --tool-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_tool_parser.py \
-    --default-chat-template-kwargs.enable_thinking false"
+    --reasoning-parser apertus \
+    --reasoning-parser-plugin /capstor/store/cscs/swissai/infra01/tool-parser-vllm/apertus_reasoning_parser.py \
+    --default-chat-template-kwargs.enable_thinking true"

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607-deliberation.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607-deliberation.sh
@@ -3,11 +3,13 @@ sml advanced \
   --tui \
   --partition normal \
   --framework vllm \
+  --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-8B-RC-2607 \
-    --served-model-name apertus-ai/Apertus-v1.5-8B-RC-2607-deliberation \
+    --served-model-name apertus-ai/Apertus-v1.5-8B-RC-deliberation \
     --skip-mm-profiling \
     --trust-remote-code \
+    --gpu-memory-utilization 0.6 \
     --max-model-len 262144 \
     --enable-auto-tool-choice \
     --tool-call-parser apertus \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607.sh
@@ -3,11 +3,13 @@ sml advanced \
   --tui \
   --partition normal \
   --framework vllm \
+  --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-8B-RC-2607 \
-    --served-model-name apertus-ai/Apertus-v1.5-8B-RC-2607 \
+    --served-model-name apertus-ai/Apertus-v1.5-8B-RC \
     --skip-mm-profiling \
     --trust-remote-code \
+    --gpu-memory-utilization 0.6 \
     --max-model-len 262144 \
     --enable-auto-tool-choice \
     --tool-call-parser apertus \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-8B-RC-2607 \
-    --served-model-name apertus-ai/Apertus-v1.5-8B-RC-2607-nothink \
+    --served-model-name apertus-ai/Apertus-v1.5-8B-RC-2607 \
     --skip-mm-profiling \
     --trust-remote-code \
     --max-model-len 262144 \


### PR DESCRIPTION
## Summary
- Rename the RC 2607 launch scripts: `*-think` → `*-deliberation` and `*-no-think` → base name, with matching `--served-model-name` updates (`apertus-ai/Apertus-v1.5-{8B,70B}-RC[-deliberation]`)
- Add `--time 12:00:00` job time limit to all four scripts
- Set `--gpu-memory-utilization` (0.8 for 70B, 0.6 for 8B)

Contains the two commits from local main (ae4cd5f, f276f06) that couldn't be pushed directly due to branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JmiajYLZzKQHnYXRJqX6E