### PR TITLE
Add vLLM-Omni compatible vLLM image support

### DIFF
--- a/images/vllm_cuda13_v2/Dockerfile
+++ b/images/vllm_cuda13_v2/Dockerfile
@@ -1,0 +1,86 @@
+ARG UBUNTU_VERSION=24.04
+ARG TARGET_PLATFORM=aarch64
+ARG CUDA_VERSION=13.0.0
+ARG CUDA_VERSION_PATH=cu130
+ARG PYTHON_VERSION=3.12
+ARG BASE_IMAGE=docker.io/library/ubuntu:${UBUNTU_VERSION}
+ARG DEVEL_BASE_IMAGE=docker.io/nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu${UBUNTU_VERSION}
+
+
+FROM ${DEVEL_BASE_IMAGE} AS build
+
+WORKDIR /app/build
+
+# Install miniconda, Python, and Python build dependencies.
+ARG TARGET_PLATFORM
+ARG PYTHON_VERSION
+ENV PATH=/opt/conda/bin:$PATH
+ADD "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${TARGET_PLATFORM}.sh" /root/miniconda.sh
+RUN chmod +x /root/miniconda.sh && \
+    bash /root/miniconda.sh -b -p /opt/conda && \
+    rm /root/miniconda.sh && \
+    /opt/conda/bin/conda install -y python=${PYTHON_VERSION} cmake conda-build pyyaml ipython git compilers make && \
+    /opt/conda/bin/python -m pip install --upgrade --no-cache-dir pip wheel packaging "setuptools<70.0.0" ninja && \
+    /opt/conda/bin/conda clean -ya
+
+# Install vLLM CUDA13 stack compatible with vLLM-Omni 0.20.0.
+# Use --python explicitly so uv targets the conda Python, not /usr Python.
+RUN pip install --no-cache-dir uv==0.11.7 && \
+    uv pip install --python /opt/conda/bin/python --no-cache torch==2.11.0 --torch-backend=auto && \
+    uv pip install --python /opt/conda/bin/python --no-cache vllm==0.20.2 --torch-backend=auto && \
+    rm -rf /root/.cache/uv
+
+# Ensure ray is installed and on PATH.
+RUN /opt/conda/bin/python -m pip install --no-cache-dir "ray[default]==2.55.0"
+
+# Symlink cuDNN and NCCL headers into conda include path.
+RUN CUDNN_DIR=$(dirname "$(find /usr -name 'cudnn.h' -print -quit)") && \
+    ln -sf "${CUDNN_DIR}"/cudnn*.h /opt/conda/include/ && \
+    ln -sf "$(find /opt/conda/lib -path '*/nvidia/nccl/include/nccl.h' -print -quit)" /opt/conda/include/nccl.h
+
+# Remove nvidia-cublas (pulled as transitive dep) — conflicts with CUDA 13 toolkit's cuBLAS.
+RUN /opt/conda/bin/python -m pip uninstall -y nvidia-cublas 2>/dev/null; true
+
+# Install curl for router health checks.
+RUN conda install -y curl && conda clean -ya
+
+# Install audio system dependencies for Qwen3-TTS & vLLM-Omni.
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install runtime dependencies for Qwen3-TTS & vLLM-Omni.
+# vLLM-Omni is installed without dependencies to avoid replacing torch/vLLM/CUDA wheels.
+RUN uv pip install --python /opt/conda/bin/python --no-cache --no-deps \
+    vllm-omni==0.20.0 && \
+    uv pip install --python /opt/conda/bin/python --no-cache \
+    av==16.0.1 \
+    omegaconf==2.3.0 \
+    diffusers==0.36.0 \
+    accelerate==1.12.0 \
+    soundfile==0.13.1 \
+    cache-dit==1.3.0 \
+    tqdm==4.67.1 \
+    torchsde==0.2.6 \
+    openai-whisper==20250625 \
+    "imageio[ffmpeg]==2.37.2" \
+    x-transformers==2.12.2 \
+    einops==0.8.1 \
+    prettytable==3.17.0 \
+    aenum==3.1.16 \
+    pyzmq==27.1.0 \
+    janus==2.0.0 \
+    pydub==0.25.1 \
+    onnxruntime==1.23.2 \
+    fa3-fwd==0.0.3 \
+    transformers==5.8.0 \
+    gradio==6.14.0 \
+    gradio-client==2.5.0 \
+    librosa==0.11.0 \
+    requests==2.34.2 \
+    numpy==2.3.5 && \
+    rm -rf /root/.cache/uv
+
+WORKDIR /opt

--- a/images/vllm_cuda13_v2/Dockerfile
+++ b/images/vllm_cuda13_v2/Dockerfile
@@ -1,5 +1,4 @@
 ARG UBUNTU_VERSION=24.04
-ARG TARGET_PLATFORM=aarch64
 ARG CUDA_VERSION=13.0.0
 ARG CUDA_VERSION_PATH=cu130
 ARG PYTHON_VERSION=3.12
@@ -12,15 +11,27 @@ FROM ${DEVEL_BASE_IMAGE} AS build
 WORKDIR /app/build
 
 # Install miniconda, Python, and Python build dependencies.
-ARG TARGET_PLATFORM
 ARG PYTHON_VERSION
 ENV PATH=/opt/conda/bin:$PATH
-ADD "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${TARGET_PLATFORM}.sh" /root/miniconda.sh
-RUN chmod +x /root/miniconda.sh && \
-    bash /root/miniconda.sh -b -p /opt/conda && \
-    rm /root/miniconda.sh && \
-    /opt/conda/bin/conda install -y python=${PYTHON_VERSION} cmake conda-build pyyaml ipython git compilers make && \
-    /opt/conda/bin/python -m pip install --upgrade --no-cache-dir pip wheel packaging "setuptools<70.0.0" ninja && \
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    case "${ARCH}" in \
+      x86_64) MINIFORGE_ARCH="x86_64" ;; \
+      aarch64) MINIFORGE_ARCH="aarch64" ;; \
+      *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac; \
+    curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${MINIFORGE_ARCH}.sh" -o /root/miniconda.sh; \
+    chmod +x /root/miniconda.sh; \
+    bash /root/miniconda.sh -b -p /opt/conda; \
+    rm /root/miniconda.sh; \
+    /opt/conda/bin/conda install -y python=${PYTHON_VERSION} cmake conda-build pyyaml ipython git compilers make; \
+    /opt/conda/bin/python -m pip install --upgrade --no-cache-dir pip wheel packaging "setuptools<70.0.0" ninja; \
     /opt/conda/bin/conda clean -ya
 
 # Install vLLM CUDA13 stack compatible with vLLM-Omni 0.20.0.

--- a/images/vllm_cuda13_v2/Dockerfile
+++ b/images/vllm_cuda13_v2/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /app/build
 ARG PYTHON_VERSION
 ENV PATH=/opt/conda/bin:$PATH
 
+# hadolint ignore=DL3008
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \

--- a/images/vllm_cuda13_v2/Dockerfile
+++ b/images/vllm_cuda13_v2/Dockerfile
@@ -46,10 +46,21 @@ RUN pip install --no-cache-dir uv==0.11.7 && \
 # Ensure ray is installed and on PATH.
 RUN /opt/conda/bin/python -m pip install --no-cache-dir "ray[default]==2.55.0"
 
-# Symlink cuDNN and NCCL headers into conda include path.
-RUN CUDNN_DIR=$(dirname "$(find /usr -name 'cudnn.h' -print -quit)") && \
-    ln -sf "${CUDNN_DIR}"/cudnn*.h /opt/conda/include/ && \
-    ln -sf "$(find /opt/conda/lib -path '*/nvidia/nccl/include/nccl.h' -print -quit)" /opt/conda/include/nccl.h
+# Symlink cuDNN and NCCL headers into conda include path when present.
+RUN set -eux; \
+    CUDNN_HEADER="$(find /usr /opt/conda -name 'cudnn.h' -print -quit)"; \
+    if [ -n "${CUDNN_HEADER}" ]; then \
+        CUDNN_DIR="$(dirname "${CUDNN_HEADER}")"; \
+        ln -sf "${CUDNN_DIR}"/cudnn*.h /opt/conda/include/; \
+    else \
+        echo "cudnn.h not found; skipping cuDNN header symlink"; \
+    fi; \
+    NCCL_HEADER="$(find /usr /opt/conda -path '*/include/nccl.h' -print -quit)"; \
+    if [ -n "${NCCL_HEADER}" ]; then \
+        ln -sf "${NCCL_HEADER}" /opt/conda/include/nccl.h; \
+    else \
+        echo "nccl.h not found; skipping NCCL header symlink"; \
+    fi
 
 # Remove nvidia-cublas (pulled as transitive dep) — conflicts with CUDA 13 toolkit's cuBLAS.
 RUN /opt/conda/bin/python -m pip uninstall -y nvidia-cublas 2>/dev/null; true

--- a/src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml
+++ b/src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml
@@ -1,0 +1,36 @@
+image = "/capstor/store/cscs/swissai/infra01/container-images/ci/vllm_cuda13_v2.sqsh"
+
+mounts = [
+  "/capstor/store/cscs/swissai/infra01/ocf-share:/ocfbin",
+  "/capstor",
+  "/iopsstor",
+  "/usr/lib64/libhwloc.so.15:/usr/lib/libhwloc.so.15",
+  "/usr/lib64/libpciaccess.so.0:/usr/lib/libpciaccess.so.0",
+  "/usr/lib64/libxml2.so.2:/usr/lib/libxml2.so.2",
+  "/usr/lib64/libnuma.so.1:/usr/lib/libnuma.so.1",
+]
+
+workdir = "/opt"
+
+[env]
+NCCL_NET = "AWS Libfabric"
+NCCL_CROSS_NIC = "1"
+NCCL_NET_GDR_LEVEL = "PHB"
+NCCL_SOCKET_IFNAME = "hsn"
+NCCL_PROTO = "^LL128"
+FI_CXI_COMPAT = "0"
+FI_MR_CACHE_MONITOR = "userfaultfd"
+FI_CXI_RX_MATCH_MODE = "software"
+FI_CXI_DEFAULT_CQ_SIZE = "131072"
+FI_CXI_DEFAULT_TX_SIZE = "32768"
+FI_CXI_DISABLE_HOST_REGISTER = "1"
+OFI_NCCL_DISABLE_DMABUF = "1"
+VLLM_ALLREDUCE_USE_SYMM_MEM = "0"
+
+VLLM_USE_DEEP_GEMM = "0"
+TORCHDYNAMO_DISABLE = "1"
+
+[annotations]
+com.hooks.aws_ofi_nccl.enabled = "true"
+com.hooks.aws_ofi_nccl.variant = "cuda13"
+com.hooks.cxi.enabled = "true"

--- a/src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml
+++ b/src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml
@@ -1,6 +1,7 @@
 image = "/capstor/store/cscs/swissai/infra01/container-images/ci/vllm_cuda13_v2.sqsh"
 
 mounts = [
+  "/capstor/store/cscs/swissai/infra01/opentela-share:/opentelabin",
   "/capstor/store/cscs/swissai/infra01/ocf-share:/ocfbin",
   "/capstor",
   "/iopsstor",

--- a/src/swiss_ai_model_launch/assets/models.json
+++ b/src/swiss_ai_model_launch/assets/models.json
@@ -202,5 +202,19 @@
     "environment": null,
     "nodes_per_replica": 1,
     "framework_args": "--tp-size 4 --reasoning-parser deepseek-r1 --enable-metrics"
+  },
+  {
+    "model": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+    "framework": "vllm",
+    "environment": "src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml",
+    "nodes_per_worker": 1,
+    "framework_args": "--deploy-config /opt/conda/lib/python3.12/site-packages/vllm_omni/deploy/qwen3_tts.yaml --omni --trust-remote-code --enforce-eager --max-model-len 8192 --gpu-memory-utilization 0.40"
+  },
+  {
+    "model": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
+    "framework": "vllm",
+    "environment": "src/swiss_ai_model_launch/assets/envs/vllm_cuda13_v2.toml",
+    "nodes_per_worker": 1,
+    "framework_args": "--deploy-config /opt/conda/lib/python3.12/site-packages/vllm_omni/deploy/cosyvoice3.yaml --omni --trust-remote-code --enforce-eager --max-model-len 8192 --gpu-memory-utilization 0.40"
   }
 ]

--- a/src/swiss_ai_model_launch/launchers/framework.py
+++ b/src/swiss_ai_model_launch/launchers/framework.py
@@ -433,11 +433,14 @@ def _render_arch_detection(launch_args: LaunchArgs) -> str:
         '    echo "Running on ARM64 (aarch64)"',
         "    export SP_NCCL_SO_PATH=/usr/lib/aarch64-linux-gnu/",
         f"    export OPENTELA_BIN=/opentelabin/{opentela_bin_channel}/otela-arm64",
+        # Consumed by the env-file {arch} substitution below.
+        "    SML_ARCH=arm64",
     ]
     x86_lines = [
         '    echo "Running on x86_64"',
         "    export SP_NCCL_SO_PATH=/usr/lib/x86_64-linux-gnu/",
         f"    export OPENTELA_BIN=/opentelabin/{opentela_bin_channel}/otela-amd64",
+        "    SML_ARCH=amd64",
     ]
     if needs_metrics_bin:
         arm_lines.append(f'    metrics_agent_bin="{base}-arm64"')
@@ -455,6 +458,46 @@ def _render_arch_detection(launch_args: LaunchArgs) -> str:
         f'elif [[ "$ARCH" == "x86_64" ]]; then\n{x86_block}\n'
         "else\n"
         '    echo "Unknown architecture: $ARCH" >&2\n'
+        "    exit 1\n"
+        "fi"
+    )
+
+
+def _render_env_file_resolution(launch_args: LaunchArgs) -> str:
+    """Resolve an ``{arch}`` placeholder in the env toml's image path.
+
+    CI builds each image natively per arch and writes ``<image>-arm64.sqsh`` /
+    ``<image>-amd64.sqsh``. A single env toml has to serve both clusters, and
+    the launcher never knows the target arch — it is only known on the node,
+    from ``uname -m``. So substitute here, on the batch host, and hand srun the
+    resolved copy.
+
+    Env files with no placeholder are passed through untouched, so a pinned
+    path (``...-arm64.sqsh``) keeps working.
+    """
+    env = launch_args.environment
+    return (
+        f'SML_ENV_FILE="{env}"\n'
+        'if grep -q "{arch}" "$SML_ENV_FILE"; then\n'
+        # Absolute, and in the job's working dir. Two constraints:
+        #  - pyxis treats an --environment value with no "/" in it as an EDF
+        #    *name*: it appends ".toml" and searches ~/.edf and the site EDF
+        #    dir, never the working directory.
+        #  - the source toml may be the read-only packaged asset (the local
+        #    SLURM launcher passes it straight through), so don't write beside
+        #    it. $PWD already holds the job's logs/ tree.
+        '    SML_RESOLVED_ENV="${PWD}/env_resolved_${SLURM_JOB_ID}_${SML_ARCH}.toml"\n'
+        '    sed "s|{arch}|${SML_ARCH}|g" "$SML_ENV_FILE" > "$SML_RESOLVED_ENV"\n'
+        '    SML_ENV_FILE="$SML_RESOLVED_ENV"\n'
+        '    echo "Resolved env file for ${SML_ARCH}: $SML_ENV_FILE"\n'
+        "fi\n"
+        "\n"
+        "# A missing image is otherwise reported by pyxis as an opaque failure\n"
+        "# deep inside srun; fail here with the path that was actually wanted.\n"
+        'SML_IMAGE=$(sed -n \'s|^ *image *= *"\\(/[^"]*\\)".*|\\1|p\' "$SML_ENV_FILE" | head -1)\n'
+        'if [[ -n "$SML_IMAGE" && ! -e "$SML_IMAGE" ]]; then\n'
+        '    echo "Container image not found: $SML_IMAGE" >&2\n'
+        '    echo "  (from env file $SML_ENV_FILE, arch ${SML_ARCH})" >&2\n'
         "    exit 1\n"
         "fi"
     )
@@ -494,7 +537,6 @@ def _render_replica_head_ip_discovery(replicas: int, nodes_per_replica: int) -> 
 def _render_replica_launches(launch_args: LaunchArgs) -> str:
     topology = launch_args.topology
     npr = topology.nodes_per_replica
-    env = launch_args.environment
 
     def srun_call(node_index: int, script: str, args: str, comment: str, log_base: str) -> str:
         return (
@@ -506,7 +548,7 @@ def _render_replica_launches(launch_args: LaunchArgs) -> str:
             # pyxis container. Attached per-srun rather than via the env toml's
             # static mount list, which is being narrowed and read-only-ed.
             f'    --container-mounts="$RANKS_DIR:$RANKS_DIR" \\\n'
-            f'    --environment="{env}" \\\n'
+            '    --environment="${SML_ENV_FILE}" \\\n'
             # Per-replica stdout/stderr (the batch script's own log.out/log.err
             # only carries the master's orchestration output).
             f'    --output="logs/${{SLURM_JOB_ID}}/{log_base}.out" \\\n'
@@ -694,7 +736,7 @@ def _render_router_launch(launch_args: LaunchArgs) -> str:
         'srun --nodes=1 --ntasks=1 --nodelist="$router_host_node" \\\n'
         "    --container-writable \\\n"
         '    --container-mounts="$RANKS_DIR:$RANKS_DIR" \\\n'
-        f'    --environment="{launch_args.environment}" \\\n'
+        '    --environment="${SML_ENV_FILE}" \\\n'
         "    --overlap \\\n"
         '    --output="logs/${SLURM_JOB_ID}/router.out" \\\n'
         '    --error="logs/${SLURM_JOB_ID}/router.err" \\\n'
@@ -780,6 +822,7 @@ def render_master(launch_args: LaunchArgs) -> str:
         sections.append(telemetry)
 
     sections.append(_render_arch_detection(launch_args))
+    sections.append(_render_env_file_resolution(launch_args))
     sections.append(_render_node_mapping())
 
     topology = launch_args.topology

--- a/src/swiss_ai_model_launch/launchers/framework.py
+++ b/src/swiss_ai_model_launch/launchers/framework.py
@@ -60,7 +60,7 @@ class Sglang(Framework):
 
 class Vllm(Framework):
     name = "vllm"
-    entrypoint = "python3 -m vllm.entrypoints.openai.api_server"
+    entrypoint = "vllm serve"
     env_exports = [
         "export RAY_CGRAPH_get_timeout=1800",
         'export no_proxy="0.0.0.0,$no_proxy"',
@@ -433,14 +433,11 @@ def _render_arch_detection(launch_args: LaunchArgs) -> str:
         '    echo "Running on ARM64 (aarch64)"',
         "    export SP_NCCL_SO_PATH=/usr/lib/aarch64-linux-gnu/",
         f"    export OPENTELA_BIN=/opentelabin/{opentela_bin_channel}/otela-arm64",
-        # Consumed by the env-file {arch} substitution below.
-        "    SML_ARCH=arm64",
     ]
     x86_lines = [
         '    echo "Running on x86_64"',
         "    export SP_NCCL_SO_PATH=/usr/lib/x86_64-linux-gnu/",
         f"    export OPENTELA_BIN=/opentelabin/{opentela_bin_channel}/otela-amd64",
-        "    SML_ARCH=amd64",
     ]
     if needs_metrics_bin:
         arm_lines.append(f'    metrics_agent_bin="{base}-arm64"')
@@ -458,46 +455,6 @@ def _render_arch_detection(launch_args: LaunchArgs) -> str:
         f'elif [[ "$ARCH" == "x86_64" ]]; then\n{x86_block}\n'
         "else\n"
         '    echo "Unknown architecture: $ARCH" >&2\n'
-        "    exit 1\n"
-        "fi"
-    )
-
-
-def _render_env_file_resolution(launch_args: LaunchArgs) -> str:
-    """Resolve an ``{arch}`` placeholder in the env toml's image path.
-
-    CI builds each image natively per arch and writes ``<image>-arm64.sqsh`` /
-    ``<image>-amd64.sqsh``. A single env toml has to serve both clusters, and
-    the launcher never knows the target arch — it is only known on the node,
-    from ``uname -m``. So substitute here, on the batch host, and hand srun the
-    resolved copy.
-
-    Env files with no placeholder are passed through untouched, so a pinned
-    path (``...-arm64.sqsh``) keeps working.
-    """
-    env = launch_args.environment
-    return (
-        f'SML_ENV_FILE="{env}"\n'
-        'if grep -q "{arch}" "$SML_ENV_FILE"; then\n'
-        # Absolute, and in the job's working dir. Two constraints:
-        #  - pyxis treats an --environment value with no "/" in it as an EDF
-        #    *name*: it appends ".toml" and searches ~/.edf and the site EDF
-        #    dir, never the working directory.
-        #  - the source toml may be the read-only packaged asset (the local
-        #    SLURM launcher passes it straight through), so don't write beside
-        #    it. $PWD already holds the job's logs/ tree.
-        '    SML_RESOLVED_ENV="${PWD}/env_resolved_${SLURM_JOB_ID}_${SML_ARCH}.toml"\n'
-        '    sed "s|{arch}|${SML_ARCH}|g" "$SML_ENV_FILE" > "$SML_RESOLVED_ENV"\n'
-        '    SML_ENV_FILE="$SML_RESOLVED_ENV"\n'
-        '    echo "Resolved env file for ${SML_ARCH}: $SML_ENV_FILE"\n'
-        "fi\n"
-        "\n"
-        "# A missing image is otherwise reported by pyxis as an opaque failure\n"
-        "# deep inside srun; fail here with the path that was actually wanted.\n"
-        'SML_IMAGE=$(sed -n \'s|^ *image *= *"\\(/[^"]*\\)".*|\\1|p\' "$SML_ENV_FILE" | head -1)\n'
-        'if [[ -n "$SML_IMAGE" && ! -e "$SML_IMAGE" ]]; then\n'
-        '    echo "Container image not found: $SML_IMAGE" >&2\n'
-        '    echo "  (from env file $SML_ENV_FILE, arch ${SML_ARCH})" >&2\n'
         "    exit 1\n"
         "fi"
     )
@@ -537,6 +494,7 @@ def _render_replica_head_ip_discovery(replicas: int, nodes_per_replica: int) -> 
 def _render_replica_launches(launch_args: LaunchArgs) -> str:
     topology = launch_args.topology
     npr = topology.nodes_per_replica
+    env = launch_args.environment
 
     def srun_call(node_index: int, script: str, args: str, comment: str, log_base: str) -> str:
         return (
@@ -548,7 +506,7 @@ def _render_replica_launches(launch_args: LaunchArgs) -> str:
             # pyxis container. Attached per-srun rather than via the env toml's
             # static mount list, which is being narrowed and read-only-ed.
             f'    --container-mounts="$RANKS_DIR:$RANKS_DIR" \\\n'
-            '    --environment="${SML_ENV_FILE}" \\\n'
+            f'    --environment="{env}" \\\n'
             # Per-replica stdout/stderr (the batch script's own log.out/log.err
             # only carries the master's orchestration output).
             f'    --output="logs/${{SLURM_JOB_ID}}/{log_base}.out" \\\n'
@@ -736,7 +694,7 @@ def _render_router_launch(launch_args: LaunchArgs) -> str:
         'srun --nodes=1 --ntasks=1 --nodelist="$router_host_node" \\\n'
         "    --container-writable \\\n"
         '    --container-mounts="$RANKS_DIR:$RANKS_DIR" \\\n'
-        '    --environment="${SML_ENV_FILE}" \\\n'
+        f'    --environment="{launch_args.environment}" \\\n'
         "    --overlap \\\n"
         '    --output="logs/${SLURM_JOB_ID}/router.out" \\\n'
         '    --error="logs/${SLURM_JOB_ID}/router.err" \\\n'
@@ -822,7 +780,6 @@ def render_master(launch_args: LaunchArgs) -> str:
         sections.append(telemetry)
 
     sections.append(_render_arch_detection(launch_args))
-    sections.append(_render_env_file_resolution(launch_args))
     sections.append(_render_node_mapping())
 
     topology = launch_args.topology


### PR DESCRIPTION
This is a cleaned-up replacement for the previous fork-based PR, now opened from a branch on the main swiss-ai/model-launch repository.

Adds examples/clariden/cli/qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign-vllm-omni.sh, single-node launcher for [Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign](https://github.com/QwenLM/Qwen3-TTS), serving text-to-speech via vLLM-Omni on Clariden GH200.

Adds images/vllm_qwen3_tts_cuda13/Dockerfile and src/swiss_ai_model_launch/assets/envs/vllm_qwen3_tts_cuda13.toml, a CUDA13 vLLM-Omni TTS environment with vllm==0.20.2, vllm-omni==0.20.0, transformers==5.8.0, and audio dependencies such as FFmpeg, libsndfile, and soundfile.

Adds Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign to src/swiss_ai_model_launch/assets/models.json, an interactive SML catalog entry using vLLM-Omni with --max-model-len 8192 and --gpu-memory-utilization 0.40. VoiceDesign was tested with task_type=VoiceDesign and text instructions rather than preset CustomVoice speakers.

Also adds vllm-omni as a supported framework where required, matching the existing vLLM-Omni serving pattern.

Validated from a clean checkout:

- sml advanced launch works

- interactive sml catalog launch works