### PR TITLE
Add --authorization launch option with Serving API whoami resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Prefer a script you can copy? Browse [`examples/`](examples/) and run any of the
 | [Getting Started](docs/getting-started.md)         | First time here                                  |
 | [Initialization](docs/initialization.md)           | Setting up credentials, FirecREST vs SLURM       |
 | [Using SML](docs/usage-sml.md)                     | Day-to-day launches via the interactive CLI      |
-| [Advanced Usage](docs/usage-advanced.md)           | Full SLURM/framework control                     |
+| [Advanced Usage](docs/usage-advanced.md)           | Full SLURM/framework control, `--authorization`  |
 | [How to Size a Model](docs/sizing.md)              | Picking replica/node layout for a given model    |
 | [Benchmarking](docs/benchmarking.md)               | Measuring throughput and latency                 |
 | [MCP Server](docs/mcp.md)                          | Driving SML from Claude Desktop / Cursor         |

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -26,6 +26,7 @@ For the guided flow with a curated catalog, use [`sml`](usage-sml.md).
 | `--handover-time`           |                      | Overlap before the previous job ends (default: `03:00:00`)                                                                     |
 | `--max-job-time`            |                      | Per-job cap for chains `HH:MM:SS` (default: `12:00:00`)                                                                        |
 | `--served-model-name`       |                      | Required: pass it here, or include `--served-model-name <name>` inside `--framework-args`. Omitting both aborts with an error. |
+| `--authorization`           | `SML_AUTHORIZATION`  | Who may use the model: `private` (default — only you), `public`, or comma-separated emails                                     |
 | `--router`                  |                      | Routing: `opentela` (default) or `sglang` (in-job router, replicas > 1)                                                        |
 | `--router-args`             |                      | Arguments forwarded to the router (`--router sglang`)                                                                          |
 | `--disable-opentela`        |                      | Disable OpenTela wrapper                                                                                                       |
@@ -162,6 +163,22 @@ After a real (non-`--output-script`) submission, the same rank scripts also land
 
 > **`master.sh` is self-contained.** Rank scripts are embedded as `cat`-heredocs and extracted at job start to `$HOME/.sml/job-${SLURM_JOB_ID}/` — shared FS, so every compute node `srun` reaches can read them. The sibling `head.sh` / `follower.sh` / `router.sh` from `--output-script` are inspection-only and never read at runtime; to hand-tune, edit the heredoc bodies inside `master.sh`.
 
+## Controlling who may use the model (`--authorization`)
+
+Every launch carries an `authorization` label on the mesh that the Serving API uses to decide who can see the model in `/v1/models` and send requests to it. Three forms are accepted (flag or `SML_AUTHORIZATION` env var):
+
+- `private` — **the default.** Only you. Before submission SML resolves this to your email by asking the Serving API who owns your configured CSCS API key; if that lookup fails (no key, bad key, no network), the launch aborts instead of submitting with the wrong audience.
+- `public` — anyone with a Serving API key (and anonymous `/v1/models` listings) can use the model.
+- `user1@epfl.ch,user2@ethz.ch` — a comma-separated email list restricting the model to those users. SML normalises the list (whitespace stripped, lowercased, duplicates dropped) before launch.
+
+```bash
+sml advanced \
+  ... \
+  --authorization "user1@epfl.ch,user2@ethz.ch"
+```
+
+Models launched before this flag existed carry no `authorization` label and stay public — nothing changes for them. Unlike [`--disable-opentela`](#when-to-disable-opentela), an authorized model still joins the mesh and is served through the public gateway; the Serving API just refuses callers outside the list.
+
 ## When to disable OpenTela
 
 > The [OpenTela project](https://github.com/swiss-ai/opentela)'s client binary ships on-disk as `otela-<arch>` and is referenced via `OPENTELA_BIN`.
@@ -171,7 +188,7 @@ By default, every replica joins the OpenTela p2p mesh at startup. That registrat
 Pass `--disable-opentela` when:
 
 - **You're benchmarking max throughput.** OpenTela adds a hop on the request path; disabling it gives you the framework's raw numbers. See [Benchmarking](benchmarking.md).
-- **You want the model kept private.** With OpenTela disabled, the replica never registers with the mesh — so serving-api can't find it and it isn't reachable from outside the cluster. Useful for private fine-tunes or in-flight experiments.
+- **You want the model kept off the mesh entirely.** With OpenTela disabled, the replica never registers — so serving-api can't find it and it isn't reachable from outside the cluster. Useful for in-flight experiments. If you just want to keep the model to yourself (or a short list of users) while still serving it through the gateway, prefer `--authorization` (previous section).
 - **You're running at scale and the mesh is in the way.** If you've stood up your own routing in front of N replicas (or you're driving load directly from another cluster job), OpenTela registration is just overhead.
 
 If you disable it, you're responsible for reaching the model yourself — usually directly via its host:port from another job on the same cluster.

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -179,6 +179,8 @@ sml advanced \
 
 Models launched before this flag existed carry no `authorization` label and stay public — nothing changes for them. Unlike [`--disable-opentela`](#when-to-disable-opentela), an authorized model still joins the mesh and is served through the public gateway; the Serving API just refuses callers outside the list.
 
+**Pick a unique `--served-model-name`.** The mesh does not reserve names: if two independent launches serve the same name with *different* authorization labels, the gateway cannot tell whose replica a request would land on, so it refuses to route that name for **everyone** (403 naming the conflict) until one side exits or is relaunched under a unique name or with a matching label. Same-label relaunches (replicas, `--consecutive` handovers, reordered email lists) are not a conflict. `sml preconfigured` avoids this by salting generated names; with `sml advanced` the name is yours to keep unique.
+
 ## When to disable OpenTela
 
 > The [OpenTela project](https://github.com/swiss-ai/opentela)'s client binary ships on-disk as `otela-<arch>` and is referenced via `OPENTELA_BIN`.

--- a/docs/usage-sml.md
+++ b/docs/usage-sml.md
@@ -12,25 +12,28 @@ After [initialization](initialization.md):
 sml
 ```
 
-You'll be prompted for: target system (FirecREST only), partition, SLURM reservation (optional, blank to skip), SLURM account (optional, blank for your default group), model, framework, replica count, routing strategy (only when replica count > 1), and time limit. SML submits the job and the TUI takes over.
+You'll be prompted for: target system (FirecREST only), partition, SLURM reservation (optional, blank to skip), SLURM account (optional, blank for your default group), model, framework, replica count, routing strategy (only when replica count > 1), time limit, and who may use the model (authorization). SML submits the job and the TUI takes over.
 
 ## Skipping the prompts
 
 You can pre-fill any prompt with a CLI flag or environment variable. Whatever you don't supply, SML asks for.
 
-| Argument        | Environment Variable | Description                                              |
-| --------------- | -------------------- | -------------------------------------------------------- |
-| `--system`      | `SML_SYSTEM`         | Target system (required if launcher is `firecrest`)      |
-| `--partition`   | `SML_PARTITION`      | SLURM partition                                          |
-| `--reservation` | `SML_RESERVATION`    | SLURM reservation (optional)                             |
-| `--account`     | `SML_ACCOUNT`        | SLURM account used for job submission (optional)         |
-| `--model`       |                      | Model to launch (`<vendor>/<model>`)                     |
-| `--framework`   |                      | Inference framework                                      |
-| `--replicas`    |                      | Number of replicas                                       |
-| `--router`      |                      | Routing strategy across replicas (`opentela` / `sglang`) |
-| `--time`        |                      | Job time limit (`HH:MM:SS`)                              |
+| Argument          | Environment Variable | Description                                              |
+| ----------------- | -------------------- | -------------------------------------------------------- |
+| `--system`        | `SML_SYSTEM`         | Target system (required if launcher is `firecrest`)      |
+| `--partition`     | `SML_PARTITION`      | SLURM partition                                          |
+| `--reservation`   | `SML_RESERVATION`    | SLURM reservation (optional)                             |
+| `--account`       | `SML_ACCOUNT`        | SLURM account used for job submission (optional)         |
+| `--model`         |                      | Model to launch (`<vendor>/<model>`)                     |
+| `--framework`     |                      | Inference framework                                      |
+| `--replicas`      |                      | Number of replicas                                       |
+| `--router`        |                      | Routing strategy across replicas (`opentela` / `sglang`) |
+| `--time`          |                      | Job time limit (`HH:MM:SS`)                              |
+| `--authorization` | `SML_AUTHORIZATION`  | Who may use the model (`private` / `public` / emails)    |
 
 CLI flags take precedence over environment variables.
+
+`--authorization` controls who can see and use the model through the Serving API. `private` (the default) restricts it to you — SML resolves it to your email via your CSCS API key before submission. See [Controlling who may use the model](usage-advanced.md#controlling-who-may-use-the-model-authorization).
 
 > The guided `sml` flow submits a single job, so `--time` must fit within the
 > 12 h SLURM cap. To keep a model up longer, use

--- a/src/swiss_ai_model_launch/cli/healthcheck/checker.py
+++ b/src/swiss_ai_model_launch/cli/healthcheck/checker.py
@@ -1,9 +1,10 @@
 import httpx
 
 from swiss_ai_model_launch.cli.healthcheck.model_health import ModelHealth
+from swiss_ai_model_launch.serving_api import SERVING_API_BASE_URL
 
 _MESSAGE = {"role": "user", "content": 'Say the word "Hello". Nothing more.'}
-_HEALTH_CHECK_URL = "https://api.swissai.svc.cscs.ch/v1/chat/completions"
+_HEALTH_CHECK_URL = f"{SERVING_API_BASE_URL}/v1/chat/completions"
 _TIMEOUT_SECONDS = 10
 _MAX_TOKENS = 16
 

--- a/src/swiss_ai_model_launch/cli/loadtest.py
+++ b/src/swiss_ai_model_launch/cli/loadtest.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import os
 import re
+import sys
 from collections.abc import Callable, Coroutine
 from datetime import datetime
 from pathlib import Path
@@ -13,6 +14,7 @@ from swiss_ai_model_launch.cli.configuration import InitConfig
 from swiss_ai_model_launch.cli.healthcheck import check_model_health
 from swiss_ai_model_launch.cli.healthcheck.model_health import ModelHealth
 from swiss_ai_model_launch.launchers import Launcher
+from swiss_ai_model_launch.launchers.authorization import resolve_authorization
 from swiss_ai_model_launch.launchers.launch_args import LaunchArgs
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.loadtest.cluster import (
@@ -26,6 +28,7 @@ from swiss_ai_model_launch.loadtest.setup import (
     K6_SCRIPT,
     resolve_prompts_file,
 )
+from swiss_ai_model_launch.serving_api import ServingApiError
 
 _DEFAULT_LOADTEST_SERVER_URL = "https://api.swissai.svc.cscs.ch"
 _DEFAULT_LOADTEST_READY_TIMEOUT_SECONDS = 1000000
@@ -63,6 +66,7 @@ class _BuildLaunchArgsFromAdvanced(Protocol):
         account: str,
         partition: str,
         telemetry_endpoint: str | None = None,
+        authorization: str = "",
     ) -> LaunchArgs: ...
 
 
@@ -479,6 +483,13 @@ async def _run_loadtest_preconfigured(
     launcher = await create_launcher(config, args)
     cscs_api_key = config.get_non_none_value("cscs_api_key")
     launch_request = await get_launch_request(launcher, args)
+    try:
+        launch_request = launch_request.model_copy(
+            update={"authorization": await resolve_authorization(launch_request.authorization, cscs_api_key)}
+        )
+    except (ServingApiError, ValueError) as e:
+        print(f"Cannot resolve the model authorization: {e}", file=sys.stderr)
+        return
     await _prompt_loadtest_scenario(args)
     loadtest_config = make_loadtest_config(args)
 
@@ -504,11 +515,17 @@ async def _run_loadtest_advanced(
     config = InitConfig.load()
     launcher = await create_launcher(config, args, True)
     cscs_api_key = config.get_non_none_value("cscs_api_key")
+    try:
+        authorization = await resolve_authorization(args.authorization, cscs_api_key)
+    except (ServingApiError, ValueError) as e:
+        print(f"Cannot resolve --authorization: {e}", file=sys.stderr)
+        return
     launch_args = build_launch_args_from_advanced(
         args,
         account=launcher.account,
         partition=launcher.partition,
         telemetry_endpoint=config.get_value("telemetry_endpoint"),
+        authorization=authorization,
     )
     loadtest_config = make_loadtest_config(args)
 

--- a/src/swiss_ai_model_launch/cli/main.py
+++ b/src/swiss_ai_model_launch/cli/main.py
@@ -26,6 +26,13 @@ from swiss_ai_model_launch.cli.healthcheck import ReplicaHealthReport, check_mod
 from swiss_ai_model_launch.cli.healthcheck.model_health import ModelHealth
 from swiss_ai_model_launch.cli.loadtest import add_loadtest_parser, run_loadtest_command
 from swiss_ai_model_launch.launchers import FirecRESTLauncher, Launcher, SlurmLauncher
+from swiss_ai_model_launch.launchers.authorization import (
+    AUTH_PRIVATE,
+    AUTH_PUBLIC,
+    default_authorization,
+    is_valid_authorization,
+    resolve_authorization,
+)
 from swiss_ai_model_launch.launchers.framework import OPENTELA_BOOTSTRAP_ADDR_DEV, render_master, render_rank_scripts
 from swiss_ai_model_launch.launchers.job_status import JobStatus
 from swiss_ai_model_launch.launchers.launch_args import (
@@ -43,6 +50,7 @@ from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntr
 from swiss_ai_model_launch.launchers.topology import Topology
 from swiss_ai_model_launch.launchers.utils import call_with_firecrest_retry, create_salt, render_sbatch_header
 from swiss_ai_model_launch.mcp import mcp as _mcp
+from swiss_ai_model_launch.serving_api import ServingApiError
 
 _OptionsFactory = Callable[[], Awaitable[OptionsDict]] | Callable[[GetValueFn], Awaitable[OptionsDict]] | None
 
@@ -159,6 +167,16 @@ def _make_launch_request_config(
                 validator=lambda v: bool(re.fullmatch(r"[0-9]{1,2}:[0-5][0-9]:[0-5][0-9]", v)),
                 default="03:00:00",
             ),
+            TextConfiguration(
+                name="authorization",
+                prompt=(
+                    f"Who may use the model: '{AUTH_PRIVATE}' (only you), "
+                    f"'{AUTH_PUBLIC}' (anyone), or comma-separated emails."
+                ),
+                validator=is_valid_authorization,
+                default=AUTH_PRIVATE,
+                env_var="SML_AUTHORIZATION",
+            ),
         ],
     )
 
@@ -257,6 +275,18 @@ def _add_advanced_launch_arguments(
         dest="served_model_name",
         default=None,
         help="Name under which the model will be served. Auto-generated if omitted.",
+    )
+    advanced_parser.add_argument(
+        "--authorization",
+        dest="authorization",
+        default=default_authorization(),
+        metavar="WHO",
+        help=(
+            f"Who may use the model through the Serving API (env: SML_AUTHORIZATION). "
+            f"'{AUTH_PRIVATE}' (default): only you — resolved to your email via your "
+            f"CSCS API key before submission. '{AUTH_PUBLIC}': anyone. Or a "
+            f"comma-separated list of user emails."
+        ),
     )
     advanced_parser.add_argument(
         "--router",
@@ -578,6 +608,9 @@ async def _get_launch_request(launcher: Launcher, args: argparse.Namespace | Non
         time=launch_req_config.get_non_none_value("time"),
         served_model_name=f"{model}-{create_salt(4)}",
         router=cast(RouterMode, launch_req_config.get_non_none_value("router")),
+        # Still raw here ("private" / "public" / emails) — the launch commands
+        # resolve it before handing the request to the launcher.
+        authorization=launch_req_config.get_non_none_value("authorization"),
     )
 
 
@@ -759,6 +792,13 @@ async def _run_preconfigured(args: argparse.Namespace) -> None:
     launcher = await _create_launcher(config, args)
     cscs_api_key = config.get_non_none_value("cscs_api_key")
     launch_request = await _get_launch_request(launcher, args)
+    try:
+        launch_request = launch_request.model_copy(
+            update={"authorization": await resolve_authorization(launch_request.authorization, cscs_api_key)}
+        )
+    except (ServingApiError, ValueError) as e:
+        print(f"Cannot resolve the model authorization: {e}", file=sys.stderr)
+        return
     launch_coro = launcher.launch_model(launch_request)
     if args.tui:
         await _run_monitor(
@@ -782,11 +822,16 @@ def build_launch_args_from_advanced(
     account: str,
     partition: str,
     telemetry_endpoint: str | None = None,
+    authorization: str = "",
 ) -> LaunchArgs:
     """Build a LaunchArgs from a parsed `sml advanced` namespace.
 
     Tests can drive this directly to validate that example shell scripts produce
     a valid LaunchArgs without going through the launcher / InitConfig.
+
+    ``authorization`` is the already-RESOLVED label value (the caller runs
+    resolve_authorization on ``args.authorization`` first — this stays sync);
+    "" emits no label.
     """
     if args.served_model_name:
         served_model_name = args.served_model_name
@@ -835,6 +880,7 @@ def build_launch_args_from_advanced(
         disable_dcgm_exporter=args.disable_dcgm_exporter,
         disable_metrics=args.disable_metrics,
         telemetry_endpoint=telemetry_endpoint,
+        authorization=authorization,
     )
 
 
@@ -847,11 +893,18 @@ async def _run_advanced(args: argparse.Namespace) -> None:
     launcher = await _create_launcher(config, args, non_interactive=True)
     cscs_api_key = config.get_non_none_value("cscs_api_key")
 
+    try:
+        authorization = await resolve_authorization(args.authorization, cscs_api_key)
+    except (ServingApiError, ValueError) as e:
+        print(f"Cannot resolve --authorization: {e}", file=sys.stderr)
+        return
+
     launch_args = build_launch_args_from_advanced(
         args,
         account=launcher.account,
         partition=launcher.partition,
         telemetry_endpoint=TELEMETRY_ENDPOINT,
+        authorization=authorization,
     )
 
     # Decide single vs. consecutive chain. --time is the total uptime; a job is

--- a/src/swiss_ai_model_launch/launchers/authorization.py
+++ b/src/swiss_ai_model_launch/launchers/authorization.py
@@ -1,0 +1,72 @@
+import os
+import re
+
+from swiss_ai_model_launch.serving_api import whoami
+
+# Values of the OpenTela peer label "authorization", read by the Serving API to
+# decide who may see and use a model. "public" (or an absent label — backward
+# compat with pre-feature launches) means anyone; a comma-separated email list
+# restricts it to those users. The literal "private" never reaches the mesh:
+# SML resolves it to the launcher's own email (via the Serving API whoami
+# endpoint) before submission.
+AUTH_PUBLIC = "public"
+AUTH_PRIVATE = "private"
+
+# Deliberately simple: enough to catch typos (missing @, spaces, no domain)
+# without re-implementing RFC 5322. The Serving API compares case-insensitively.
+_EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+
+
+def normalize_email_list(raw: str) -> str:
+    """Normalise a comma-separated email list: strip, lowercase, dedupe preserving order.
+
+    Raises ValueError when any entry is empty or not a syntactically valid email.
+    """
+    seen: list[str] = []
+    for part in raw.split(","):
+        email = part.strip().lower()
+        if not _EMAIL_RE.fullmatch(email):
+            raise ValueError(
+                f"Invalid email address in authorization list: {part.strip()!r}. "
+                f"Expected '{AUTH_PUBLIC}', '{AUTH_PRIVATE}', or comma-separated emails."
+            )
+        if email not in seen:
+            seen.append(email)
+    return ",".join(seen)
+
+
+def default_authorization() -> str:
+    """The default raw value when the user gives none: SML_AUTHORIZATION from
+    the environment, else "private". Shared by every launch surface (advanced
+    parser, wizard, MCP tool) so their defaults can't drift."""
+    return os.environ.get("SML_AUTHORIZATION", AUTH_PRIVATE)
+
+
+def parse_authorization(raw: str) -> str:
+    """Validate and normalise a raw --authorization value, without resolving "private"."""
+    value = raw.strip().lower()
+    if value in (AUTH_PUBLIC, AUTH_PRIVATE):
+        return value
+    return normalize_email_list(raw)
+
+
+def is_valid_authorization(raw: str) -> bool:
+    """Predicate form of `parse_authorization`, for wizard/prompt validators."""
+    try:
+        parse_authorization(raw)
+    except ValueError:
+        return False
+    return True
+
+
+async def resolve_authorization(raw: str, cscs_api_key: str) -> str:
+    """Resolve a raw --authorization value to the label emitted on the mesh.
+
+    Only the literal "private" needs the network: it becomes the launcher's own
+    email, looked up via the Serving API whoami endpoint with their CSCS API
+    key. "public" and explicit email lists resolve locally.
+    """
+    parsed = parse_authorization(raw)
+    if parsed == AUTH_PRIVATE:
+        return (await whoami(cscs_api_key)).strip().lower()
+    return parsed

--- a/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
@@ -135,6 +135,7 @@ class FirecRESTLauncher(Launcher):
             pre_launch_cmds=launch_request.pre_launch_cmds or "",
             telemetry_endpoint=self.telemetry_endpoint,
             router=launch_request.router,
+            authorization=launch_request.authorization,
         )
 
     def _get_local_env_file_path(self, launch_request: LaunchRequest) -> str:

--- a/src/swiss_ai_model_launch/launchers/framework.py
+++ b/src/swiss_ai_model_launch/launchers/framework.py
@@ -94,6 +94,11 @@ def _opentela_labels(launch_args: LaunchArgs) -> str:
         f"served_model_name={launch_args.served_model_name}",
         f"framework_args={framework_args_normalised}",
     ]
+    if launch_args.authorization:
+        # Empty means no label at all: the Serving API treats an absent
+        # authorization label as public, which keeps pre-feature launches
+        # (and scripts that never pass --authorization) working unchanged.
+        user_input.append(f"authorization={launch_args.authorization}")
     quoted = " \\\n".join(f"    --label {shlex.quote(kv)}" for kv in user_input)
     seconds = time_str_to_seconds(launch_args.time)
     return (

--- a/src/swiss_ai_model_launch/launchers/launch_args.py
+++ b/src/swiss_ai_model_launch/launchers/launch_args.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from swiss_ai_model_launch.launchers.authorization import AUTH_PRIVATE, AUTH_PUBLIC, normalize_email_list
 from swiss_ai_model_launch.launchers.topology import Topology
 
 # Routing strategy across replicas. OpenTela (default): OpenTela load-balances across
@@ -88,6 +89,13 @@ class LaunchArgs(BaseModel):
     previous_job_id: int | None = None
     environment: str
 
+    # RESOLVED authorization label value: "public", a comma-separated email
+    # list, or "" to emit no label at all (legacy behavior — the Serving API
+    # treats a missing label as public). The raw "private" must be resolved to
+    # the launcher's email (see authorization.resolve_authorization) before a
+    # LaunchArgs is built; the validator below enforces that.
+    authorization: str = ""
+
     framework: str
     framework_args: str = ""
     pre_launch_cmds: str = ""
@@ -107,6 +115,16 @@ class LaunchArgs(BaseModel):
     def _validate(self) -> "LaunchArgs":
         if not self.disable_metrics and not self.metrics_remote_write_url:
             raise ValueError("Metrics require a remote write URL when metrics are enabled.")
+        if self.authorization == AUTH_PRIVATE:
+            # Reaching this point with the raw "private" means resolution was
+            # skipped — emitting it would make the model unusable for everyone.
+            raise ValueError(
+                "authorization must be resolved before building LaunchArgs; "
+                "the literal 'private' means resolve_authorization was skipped."
+            )
+        if self.authorization and self.authorization != AUTH_PUBLIC:
+            # Raises with an actionable message when it isn't a valid email list.
+            normalize_email_list(self.authorization)
         if _PORT_FLAG_RE.search(self.framework_args):
             warnings.warn(
                 f"`--port` in framework_args is redundant; the framework port is hardcoded "

--- a/src/swiss_ai_model_launch/launchers/launch_request.py
+++ b/src/swiss_ai_model_launch/launchers/launch_request.py
@@ -2,6 +2,7 @@ from typing import Literal, Self
 
 from pydantic import BaseModel
 
+from swiss_ai_model_launch.launchers.authorization import AUTH_PRIVATE
 from swiss_ai_model_launch.launchers.launch_args import ROUTER_OPENTELA, RouterMode
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
 
@@ -18,6 +19,10 @@ class LaunchRequest(BaseModel):
     pre_launch_cmds: str | None = None
     router: RouterMode = ROUTER_OPENTELA
     model_path: str | None = None
+    # Raw-or-resolved authorization value. Callers (CLI, MCP) resolve it via
+    # authorization.resolve_authorization before handing the request to a
+    # launcher; the LaunchArgs validator rejects an unresolved "private".
+    authorization: str = AUTH_PRIVATE
 
     @classmethod
     def from_catalog_entry(
@@ -28,6 +33,7 @@ class LaunchRequest(BaseModel):
         time: str,
         served_model_name: str | None = None,
         router: RouterMode = ROUTER_OPENTELA,
+        authorization: str = AUTH_PRIVATE,
     ) -> Self:
         return cls(
             model=entry.model,
@@ -41,4 +47,5 @@ class LaunchRequest(BaseModel):
             served_model_name=served_model_name,
             router=router,
             model_path=entry.model_path,
+            authorization=authorization,
         )

--- a/src/swiss_ai_model_launch/launchers/slurm_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/slurm_launcher.py
@@ -94,6 +94,7 @@ class SlurmLauncher(Launcher):
             pre_launch_cmds=launch_request.pre_launch_cmds or "",
             telemetry_endpoint=self.telemetry_endpoint,
             router=launch_request.router,
+            authorization=launch_request.authorization,
         )
 
     def _get_local_env_file_path(self, launch_request: LaunchRequest) -> str:

--- a/src/swiss_ai_model_launch/mcp/server.py
+++ b/src/swiss_ai_model_launch/mcp/server.py
@@ -14,10 +14,12 @@ from fastmcp import Context
 from swiss_ai_model_launch.cli.configuration import InitConfig
 from swiss_ai_model_launch.cli.healthcheck import ModelHealth, check_model_health
 from swiss_ai_model_launch.launchers import FirecRESTLauncher, Launcher, SlurmLauncher
+from swiss_ai_model_launch.launchers.authorization import default_authorization, resolve_authorization
 from swiss_ai_model_launch.launchers.job_status import JobStatus
 from swiss_ai_model_launch.launchers.launch_args import TELEMETRY_ENDPOINT
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.utils import call_with_firecrest_retry, create_salt
+from swiss_ai_model_launch.serving_api import ServingApiError
 
 _POLL_INTERVAL_SECONDS = 10
 _TERMINAL_STATUSES = {JobStatus.TIMEOUT, JobStatus.UNKNOWN}
@@ -257,12 +259,25 @@ async def launch_preconfigured_model(
         "the replica peers on the mesh. 'sglang': an in-job SGLang router fronts the replicas "
         "and becomes the served endpoint (needs replicas > 1).",
     ] = "opentela",
+    authorization: Annotated[
+        str | None,
+        "Who may use the model through the Serving API. 'private': only the "
+        "launcher — resolved to their email via the configured CSCS API key before "
+        "submission. 'public': anyone. Or a comma-separated list of user emails. "
+        "Defaults to the SML_AUTHORIZATION env var, else 'private'.",
+    ] = None,
 ) -> str:
     """Launch a preconfigured model on an HPC cluster and wait for it to become healthy.
 
     Looks up the model in the catalogue by vendor/name and framework, then submits a
     SLURM job using the preconfigured settings (nodes, environment, framework arguments).
     Call `list_preconfigured_models` first to verify the model and framework are available.
+
+    The `authorization` parameter controls who can see and use the model through the
+    Serving API: 'private' (only the launcher), 'public' (anyone), or a comma-separated
+    email list. Omitted, it defaults to the SML_AUTHORIZATION env var, else 'private'.
+    'private' requires a configured CSCS API key so SML can resolve the launcher's
+    email before submission.
 
     While waiting, this tool emits MCP notifications for each new log line (prefixed
     '[stdout]' or '[stderr]') and periodic '[status]' lines with the current job state
@@ -290,17 +305,26 @@ async def launch_preconfigured_model(
             f"Model '{model}' with framework '{framework}' was not found in the catalogue. "
             "Use `list_preconfigured_models` to see available models."
         )
+    config = InitConfig.load()
+    cscs_api_key = config.get_value("cscs_api_key")
+    if authorization is None:
+        # Same default chain as the CLI (env override, else private). Read at
+        # call time, not import time, so a long-running server tracks the env.
+        authorization = default_authorization()
+    try:
+        resolved_authorization = await resolve_authorization(authorization, cscs_api_key or "")
+    except (ServingApiError, ValueError) as e:
+        return f"Cannot resolve the model authorization: {e}"
     request = LaunchRequest.from_catalog_entry(
         entry,
         replicas=replicas,
         time=time,
         served_model_name=f"{model}-{create_salt(4)}",
         router=router,
+        authorization=resolved_authorization,
     )
     job_id, served = await launcher.launch_model(request)
     await ctx.info(f"Job submitted — job_id={job_id}, served_model_name={served}")
-    config = InitConfig.load()
-    cscs_api_key = config.get_value("cscs_api_key")
     stdout_lines_sent = 0
     stderr_lines_sent = 0
     ever_healthy = False

--- a/src/swiss_ai_model_launch/serving_api.py
+++ b/src/swiss_ai_model_launch/serving_api.py
@@ -1,0 +1,45 @@
+import httpx
+
+# Public Serving API gateway. Shared by the health checker (inference probes go
+# through the same gateway users hit) and the whoami lookup that resolves
+# `--authorization private` to the launcher's own email before submission.
+SERVING_API_BASE_URL = "https://api.swissai.svc.cscs.ch"
+
+_WHOAMI_URL = f"{SERVING_API_BASE_URL}/v1/whoami"
+_TIMEOUT_SECONDS = 10
+
+
+class ServingApiError(RuntimeError):
+    """A Serving API call failed in a way the user has to act on (bad key, no network)."""
+
+
+async def whoami(api_key: str) -> str:
+    """Resolve the email that owns ``api_key`` via the Serving API whoami endpoint."""
+    if not api_key:
+        raise ServingApiError(
+            "No CSCS API key is configured, so SML cannot look up your email. "
+            "Run `sml init` to set one (get a key at https://serving.swissai.svc.cscs.ch)."
+        )
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                _WHOAMI_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=_TIMEOUT_SECONDS,
+            )
+    except (httpx.TransportError, httpx.TimeoutException) as e:
+        raise ServingApiError(
+            f"Could not reach the Serving API at {_WHOAMI_URL} ({e}). Check your network connection and retry."
+        ) from e
+    if response.status_code != 200:
+        raise ServingApiError(
+            f"The Serving API rejected the CSCS API key (HTTP {response.status_code}). "
+            "Run `sml init` to update it (get a key at https://serving.swissai.svc.cscs.ch)."
+        )
+    try:
+        email = response.json().get("email")
+    except ValueError:
+        email = None
+    if not email or not isinstance(email, str):
+        raise ServingApiError(f"The Serving API whoami response at {_WHOAMI_URL} did not contain an email.")
+    return email

--- a/tests/unit/test_advanced_cli_authorization.py
+++ b/tests/unit/test_advanced_cli_authorization.py
@@ -1,0 +1,104 @@
+import pytest
+
+from swiss_ai_model_launch.cli.main import (
+    _build_parser,
+    build_launch_args_from_advanced,
+)
+
+
+def _minimal_advanced_args(*extra: str):
+    parser = _build_parser()
+    tokens = [
+        "advanced",
+        "--system",
+        "clariden",
+        "--partition",
+        "normal",
+        "--framework",
+        "sglang",
+        "--environment",
+        "/path/to/env.toml",
+        "--framework-args",
+        "--served-model-name vendor/model-abc",
+        *extra,
+    ]
+    return parser.parse_args(tokens)
+
+
+def test_advanced_authorization_defaults_to_private(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SML_AUTHORIZATION", raising=False)
+    args = _minimal_advanced_args()
+    assert args.authorization == "private"
+
+
+def test_advanced_authorization_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SML_AUTHORIZATION", "public")
+    args = _minimal_advanced_args()
+    assert args.authorization == "public"
+
+
+def test_advanced_authorization_flag_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SML_AUTHORIZATION", "public")
+    args = _minimal_advanced_args("--authorization", "user@epfl.ch")
+    assert args.authorization == "user@epfl.ch"
+
+
+def test_build_launch_args_default_emits_no_label() -> None:
+    args = _minimal_advanced_args()
+    la = build_launch_args_from_advanced(args, account="proj01", partition="normal")
+    assert la.authorization == ""
+
+
+def test_build_launch_args_threads_resolved_authorization() -> None:
+    # The caller resolves first (private -> the launcher's email); this only
+    # checks the already-resolved value is threaded through to LaunchArgs.
+    args = _minimal_advanced_args()
+    la = build_launch_args_from_advanced(
+        args,
+        account="proj01",
+        partition="normal",
+        authorization="user@epfl.ch",
+    )
+    assert la.authorization == "user@epfl.ch"
+
+
+def test_preconfigured_authorization_is_parsed() -> None:
+    parser = _build_parser()
+    args = parser.parse_args(
+        [
+            "preconfigured",
+            "--system",
+            "clariden",
+            "--partition",
+            "normal",
+            "--model",
+            "vendor/model-abc",
+            "--framework",
+            "sglang",
+            "--replicas",
+            "1",
+            "--router",
+            "opentela",
+            "--time",
+            "02:00:00",
+            "--authorization",
+            "public",
+        ]
+    )
+    assert args.authorization == "public"
+
+
+def test_loadtest_advanced_authorization_is_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SML_AUTHORIZATION", raising=False)
+    parser = _build_parser()
+    args = parser.parse_args(
+        [
+            "loadtest",
+            "advanced",
+            "--framework",
+            "sglang",
+            "--environment",
+            "/path/to/env.toml",
+        ]
+    )
+    assert args.authorization == "private"

--- a/tests/unit/test_authorization.py
+++ b/tests/unit/test_authorization.py
@@ -1,0 +1,111 @@
+import pytest
+
+from swiss_ai_model_launch.launchers.authorization import (
+    AUTH_PRIVATE,
+    AUTH_PUBLIC,
+    default_authorization,
+    is_valid_authorization,
+    normalize_email_list,
+    parse_authorization,
+    resolve_authorization,
+)
+from swiss_ai_model_launch.serving_api import ServingApiError, whoami
+
+
+def test_parse_public_and_private_pass_through() -> None:
+    assert parse_authorization(AUTH_PUBLIC) == AUTH_PUBLIC
+    assert parse_authorization(AUTH_PRIVATE) == AUTH_PRIVATE
+
+
+def test_parse_keywords_are_case_and_whitespace_insensitive() -> None:
+    assert parse_authorization(" Public ") == AUTH_PUBLIC
+    assert parse_authorization("PRIVATE") == AUTH_PRIVATE
+
+
+def test_parse_normalizes_email_list() -> None:
+    assert parse_authorization(" User1@EPFL.ch , user2@ethz.ch ") == "user1@epfl.ch,user2@ethz.ch"
+
+
+def test_normalize_email_list_dedupes_preserving_order() -> None:
+    assert normalize_email_list("b@x.ch,a@x.ch,B@X.CH,a@x.ch") == "b@x.ch,a@x.ch"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "not-an-email",
+        "user@",
+        "@epfl.ch",
+        "user@host",  # no TLD dot
+        "a@b.ch,,c@d.ch",  # empty entry
+        "a@b.ch,nonsense",
+        "two words@epfl.ch",
+    ],
+)
+def test_invalid_values_are_rejected(raw: str) -> None:
+    with pytest.raises(ValueError, match="authorization"):
+        parse_authorization(raw)
+    assert not is_valid_authorization(raw)
+
+
+def test_is_valid_authorization_accepts_grammar() -> None:
+    for raw in (AUTH_PUBLIC, AUTH_PRIVATE, "user@epfl.ch", "a@b.ch, C@D.ch"):
+        assert is_valid_authorization(raw)
+
+
+def test_default_authorization_is_private(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SML_AUTHORIZATION", raising=False)
+    assert default_authorization() == AUTH_PRIVATE
+
+
+def test_default_authorization_honours_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SML_AUTHORIZATION", AUTH_PUBLIC)
+    assert default_authorization() == AUTH_PUBLIC
+
+
+def test_mcp_tool_defers_to_the_shared_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The MCP launch tool must not freeze 'private' into its signature: its
+    default is None so the shared env-aware default chain runs at call time
+    (a long-running server tracks SML_AUTHORIZATION like the CLI does)."""
+    import inspect
+
+    from swiss_ai_model_launch.mcp.server import launch_preconfigured_model
+
+    sig = inspect.signature(launch_preconfigured_model)
+    assert sig.parameters["authorization"].default is None
+
+
+async def test_resolve_private_uses_whoami_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_whoami(api_key: str) -> str:
+        assert api_key == "sk-rc-test"
+        # The backend also compares case-insensitively, but the label should
+        # already carry the canonical (stripped, lowercased) form.
+        return " User@EPFL.ch "
+
+    monkeypatch.setattr("swiss_ai_model_launch.launchers.authorization.whoami", fake_whoami)
+    assert await resolve_authorization(AUTH_PRIVATE, "sk-rc-test") == "user@epfl.ch"
+
+
+async def test_resolve_public_and_emails_skip_whoami(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fail_whoami(api_key: str) -> str:
+        raise AssertionError("whoami must only run for 'private'")
+
+    monkeypatch.setattr("swiss_ai_model_launch.launchers.authorization.whoami", fail_whoami)
+    assert await resolve_authorization(AUTH_PUBLIC, "") == AUTH_PUBLIC
+    assert await resolve_authorization("User@epfl.ch, other@ethz.ch", "") == "user@epfl.ch,other@ethz.ch"
+
+
+async def test_resolve_propagates_whoami_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_whoami(api_key: str) -> str:
+        raise ServingApiError("whoami is down")
+
+    monkeypatch.setattr("swiss_ai_model_launch.launchers.authorization.whoami", fake_whoami)
+    with pytest.raises(ServingApiError, match="whoami is down"):
+        await resolve_authorization(AUTH_PRIVATE, "sk-rc-test")
+
+
+async def test_whoami_without_key_fails_before_the_network() -> None:
+    # Missing key must abort with a `sml init` hint instead of a confusing 401.
+    with pytest.raises(ServingApiError, match="sml init"):
+        await whoami("")

--- a/tests/unit/test_launch_args_validation.py
+++ b/tests/unit/test_launch_args_validation.py
@@ -32,3 +32,31 @@ def test_disabled_metrics_allow_no_remote_write_url() -> None:
         metrics_remote_write_url="",
         disable_dcgm_exporter=True,
     )
+
+
+def test_authorization_defaults_to_empty() -> None:
+    # Empty means no label is emitted — the pre-feature (public) behavior.
+    assert _make_args().authorization == ""
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "public", "user@epfl.ch", "user1@epfl.ch,user2@ethz.ch"],
+)
+def test_authorization_accepts_resolved_values(value: str) -> None:
+    assert _make_args(authorization=value).authorization == value
+
+
+def test_authorization_rejects_unresolved_private() -> None:
+    # "private" reaching LaunchArgs means resolve_authorization was skipped.
+    with pytest.raises(ValidationError, match="resolved"):
+        _make_args(authorization="private")
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["nonsense", "user@", "a@b.ch,nope", "a@b.ch,,c@d.ch"],
+)
+def test_authorization_rejects_non_grammar_values(value: str) -> None:
+    with pytest.raises(ValidationError, match="authorization"):
+        _make_args(authorization=value)

--- a/tests/unit/test_rank_script_content.py
+++ b/tests/unit/test_rank_script_content.py
@@ -103,6 +103,31 @@ def test_opentela_labels_include_framework_args():
     assert "--label 'framework_args=--port 8080 --model /path/to/model --tp 4'" in head
 
 
+def test_opentela_labels_include_authorization_when_set():
+    args = _make_args(
+        authorization="user1@epfl.ch,user2@ethz.ch",
+        topology=Topology(replicas=1, nodes_per_replica=2),
+    )
+    scripts = render_rank_scripts(args)
+    # Head and follower carry the same labels, so the Serving API can filter
+    # pending/follower peers identically to the head.
+    for s in (scripts["head.sh"], scripts["follower.sh"]):
+        assert "--label authorization=user1@epfl.ch,user2@ethz.ch" in s
+
+
+def test_opentela_labels_include_authorization_public():
+    args = _make_args(authorization="public", topology=Topology(replicas=1, nodes_per_replica=1))
+    head = render_rank_scripts(args)["head.sh"]
+    assert "--label authorization=public" in head
+
+
+def test_opentela_labels_omit_authorization_when_empty():
+    # No label at all = public on the Serving API side (backward compat).
+    args = _make_args(topology=Topology(replicas=1, nodes_per_replica=1))
+    head = render_rank_scripts(args)["head.sh"]
+    assert "authorization" not in head
+
+
 def test_opentela_labels_framework_args_whitespace_normalised():
     args = _make_args(
         framework_args="--model /m     --tp 4\n    --max-len 8192",


### PR DESCRIPTION
## Summary

New `--authorization` option controlling who may see and use a launched model through the Serving API. Companion to swiss-ai/serving-api#91, which adds the `/v1/whoami` endpoint, per-caller model filtering, and inference enforcement.

- `sml ... --authorization private` (**default**; overridable via `SML_AUTHORIZATION`): only the launcher. SML resolves it to the launcher's email before submission via the Serving API's new `GET /v1/whoami`, authenticated with the configured CSCS API key — the literal `private` never reaches OpenTela, and a `LaunchArgs` validator rejects unresolved values as a guardrail.
- `sml ... --authorization public`: anyone.
- `sml ... --authorization user1@epfl.ch,user2@ethz.ch`: only the listed users (emails stripped, lowercased, syntax-validated, deduped).

The resolved value is emitted as an OpenTela peer label (`--label authorization=...`) alongside `launched_by` etc. An absent label still means public, so existing launches are unaffected.

## Changes

- `launchers/authorization.py` (new): grammar parsing/normalization, the shared env-aware default chain, and `resolve_authorization` (only `private` touches the network).
- `serving_api.py` (new): `SERVING_API_BASE_URL` + async `whoami` client (httpx, 10s timeout, actionable errors); the health checker URL now derives from the shared constant.
- Threaded through all four launch surfaces: `sml advanced` (argparse flag), the preconfigured wizard (`authorization` prompt, env `SML_AUTHORIZATION`), `sml loadtest`, and the MCP `launch_preconfigured_model` tool (defers to the shared default at call time so a long-running server tracks the env).
- `LaunchArgs.authorization` (resolved value; empty emits no label) rendered into the OpenTela label block on head, follower, and router shapes; `LaunchRequest` carries it through both launchers.
- On whoami failure (no key configured, network error, non-200) the launch aborts with a clear message instead of submitting.
- Docs: `docs/usage-advanced.md`, `docs/usage-sml.md`, README table row.

## Test plan

- `uv run --frozen pytest tests/unit/ -q`: **423 passed** (38 new: grammar matrix, resolution paths with whoami mocked, LaunchArgs accept/reject incl. unresolved-`private`, rank-script label rendering on head/follower/public/empty, parser default + env override + flag precedence, MCP default deferral).
- `ruff check` / `ruff format --check`: clean. `mypy src` (strict): clean. markdownlint on touched docs: clean.

## Notes for reviewers

- An explicit email list does **not** auto-include the launcher.
- `sml advanced --output-script` with the default `private` now performs the whoami call before rendering (the label is embedded in the rendered script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA7PtcMPSV6cim7TARFE54