### PR TITLE
Authorization Scheme

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -56,6 +56,12 @@ One independent copy of the model (a [DP](sizing.md#parallelism-dp-tp-pp-ep-and-
 
 A SLURM concept — a slot of nodes pre-allocated to a user/group, bypassing the normal queue. Set via `--reservation` (advanced) or `--reservation` (interactive). Optional.
 
+## Model authorization
+
+Who may list and use a served model. Set at launch via `--authorization`: `public` (the default — anyone), `private` (only you), or a comma-separated email list (exactly those users — it does not implicitly include you). It travels to the mesh as an OpenTela peer label and is enforced by the Serving API, which hides unauthorized models from `/v1/models` and answers `403` on inference routes.
+
+`private` never reaches the mesh: the gateway has no idea who launched a job, so SML resolves it to your own email via the Serving API's `/v1/whoami` before submitting. Because OpenTela load-balances a [served-model name](#served-model-name) across every peer advertising it, two launches sharing a name with *different* policies make that name unroutable for everyone — SML refuses such a launch up front. See [Model authorization](usage-advanced.md#model-authorization).
+
 ## Router
 
 A framework-side load balancer (e.g. `sglang-router`) inserted in front of N replicas inside one SLURM job. Enabled via `--router sglang` (the default `--router opentela` skips it and lets OpenTela balance across the replica peers). Orthogonal to [OpenTela](#opentela): the router shapes traffic *within* the job; OpenTela picks *which* job/peer a request lands on.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -56,6 +56,12 @@ One independent copy of the model (a [DP](sizing.md#parallelism-dp-tp-pp-ep-and-
 
 A SLURM concept — a slot of nodes pre-allocated to a user/group, bypassing the normal queue. Set via `--reservation` (advanced) or `--reservation` (interactive). Optional.
 
+## Launch labels
+
+Facts about a launch that SML attaches to its [OpenTela](#opentela) peer, which the gateway reads back — visible per model in `/v1/models_detailed`. Set at peer start and fixed for the job's life:
+
+`launched_by`, `slurm_job_id`, `slurm_partition`, `worker_group_id`, `framework`, `framework_args`, `served_model_name`, `started_at`, `expires_at`, [`authorization`](#model-authorization), and `sml_version` — the version of SML that rendered the launch script, resolved on the submitting machine (SML isn't installed on the compute node). It answers "which SML launched this?" when a running model behaves unexpectedly, e.g. whether it predates a fix.
+
 ## Model authorization
 
 Who may list and use a served model. Set at launch via `--authorization`: `public` (the default — anyone), `private` (only you), or a comma-separated email list (exactly those users — it does not implicitly include you). It travels to the mesh as an OpenTela peer label and is enforced by the Serving API, which hides unauthorized models from `/v1/models` and answers `403` on inference routes.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -70,7 +70,7 @@ A framework-side load balancer (e.g. `sglang-router`) inserted in front of N rep
 
 The name a client uses to request the model from the public gateway. SML namespaces it under your cluster username — `<username>/<vendor>/<model>`, e.g. `alice/swiss-ai/Apertus-8B-Instruct-2509` — so two people launching the same model never collide.
 
-Set via `--served-model-name`, with the namespace spelled out — the examples write `$USER/<vendor>/<model>`. A name already under your own username is used as-is; a name under someone *else's* username is rejected before submission; a name passed without a namespace still gets your username prepended, so older scripts keep working. Omit the flag in `sml preconfigured` and the model id is used.
+Set via `--served-model-name`, with the namespace spelled out — the examples write `$USER/<vendor>/<model>`. A name already under your own username is used as-is; a name under someone *else's* username is rejected before submission; a name passed without a namespace still gets your username prepended, so older scripts keep working. Omit the flag — as `sml preconfigured` and the MCP tool do — and SML derives `<username>/<vendor>/<model>-<framework>`. The framework suffix is what keeps your sglang and vllm deployments of one model from landing on the mesh under a single id.
 
 The gateway lists only ids of the form `<namespace>/<vendor>/<model>` (three non-empty segments) from peers running a recent enough OpenTela. It does **not** currently verify that the namespace matches the job's `launched_by` label, so the namespace is a convention that prevents accidental collisions, not an ownership claim it enforces.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -70,9 +70,9 @@ A framework-side load balancer (e.g. `sglang-router`) inserted in front of N rep
 
 The name a client uses to request the model from the public gateway. SML namespaces it under your cluster username — `<username>/<vendor>/<model>`, e.g. `alice/swiss-ai/Apertus-8B-Instruct-2509` — so two people launching the same model never collide.
 
-Set via `--served-model-name`. A name passed without a namespace (`swiss-ai/Apertus-8B-Instruct-2509`) gets your username prepended for you; a name already under your own username is left alone; a name under someone *else's* username is rejected before submission. Omit the flag in `sml preconfigured` and the model id is used.
+Set via `--served-model-name`, with the namespace spelled out — the examples write `$USER/<vendor>/<model>`. A name already under your own username is used as-is; a name under someone *else's* username is rejected before submission; a name passed without a namespace still gets your username prepended, so older scripts keep working. Omit the flag in `sml preconfigured` and the model id is used.
 
-The gateway cross-checks the namespace against the job's `launched_by` label and refuses to list or route a peer serving under a username that isn't its own.
+The gateway lists only ids of the form `<namespace>/<vendor>/<model>` (three non-empty segments) from peers running a recent enough OpenTela. It does **not** currently verify that the namespace matches the job's `launched_by` label, so the namespace is a convention that prevents accidental collisions, not an ownership claim it enforces.
 
 ## serving-api
 

--- a/docs/loadtesting.md
+++ b/docs/loadtesting.md
@@ -100,7 +100,7 @@ sml loadtest advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509 \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509 \
     --host 0.0.0.0 \
     --port 8080" \
   --loadtest-scenario throughput \

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -10,31 +10,32 @@ For the guided flow with a curated catalog, use [`sml`](usage-sml.md).
 
 ## Arguments
 
-| Argument                    | Environment Variable | Description                                                                                                                    |
-| --------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `--system`                  | `SML_SYSTEM`         | Target HPC system                                                                                                              |
-| `--partition`               | `SML_PARTITION`      | SLURM partition                                                                                                                |
-| `--account`                 | `SML_ACCOUNT`        | SLURM account used for job submission                                                                                          |
-| `--reservation`             | `SML_RESERVATION`    | SLURM reservation (optional)                                                                                                   |
-| `--framework`               |                      | Inference framework (`sglang`, `vllm`) — **required**                                                                          |
-| `--environment`             |                      | Local path to the environment `.toml` file — **required**                                                                      |
-| `--framework-args`          |                      | Arguments forwarded to the inference framework                                                                                 |
-| `--replicas`                |                      | Number of replicas (default: `1`)                                                                                              |
-| `--nodes-per-replica`       |                      | Nodes per replica (default: `1`)                                                                                               |
-| `--time`                    |                      | Total uptime `HH:MM:SS` (default: `02:00:00`)                                                                                  |
-| `--consecutive`             |                      | Serve a `--time` longer than the per-job cap with a chain of jobs                                                              |
-| `--handover-time`           |                      | Overlap before the previous job ends (default: `03:00:00`)                                                                     |
-| `--max-job-time`            |                      | Per-job cap for chains `HH:MM:SS` (default: `12:00:00`)                                                                        |
+| Argument                    | Environment Variable | Description                                                                                                                                                                                       |
+| --------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--system`                  | `SML_SYSTEM`         | Target HPC system                                                                                                                                                                                 |
+| `--partition`               | `SML_PARTITION`      | SLURM partition                                                                                                                                                                                   |
+| `--account`                 | `SML_ACCOUNT`        | SLURM account used for job submission                                                                                                                                                             |
+| `--reservation`             | `SML_RESERVATION`    | SLURM reservation (optional)                                                                                                                                                                      |
+| `--framework`               |                      | Inference framework (`sglang`, `vllm`) — **required**                                                                                                                                             |
+| `--environment`             |                      | Local path to the environment `.toml` file — **required**                                                                                                                                         |
+| `--framework-args`          |                      | Arguments forwarded to the inference framework                                                                                                                                                    |
+| `--replicas`                |                      | Number of replicas (default: `1`)                                                                                                                                                                 |
+| `--nodes-per-replica`       |                      | Nodes per replica (default: `1`)                                                                                                                                                                  |
+| `--time`                    |                      | Total uptime `HH:MM:SS` (default: `02:00:00`)                                                                                                                                                     |
+| `--consecutive`             |                      | Serve a `--time` longer than the per-job cap with a chain of jobs                                                                                                                                 |
+| `--handover-time`           |                      | Overlap before the previous job ends (default: `03:00:00`)                                                                                                                                        |
+| `--max-job-time`            |                      | Per-job cap for chains `HH:MM:SS` (default: `12:00:00`)                                                                                                                                           |
 | `--served-model-name`       |                      | Required: pass it here, or include `--served-model-name <name>` inside `--framework-args`. Omitting both aborts with an error. Namespaced under your username automatically — see the note below. |
-| `--router`                  |                      | Routing: `opentela` (default) or `sglang` (in-job router, replicas > 1)                                                        |
-| `--router-args`             |                      | Arguments forwarded to the router (`--router sglang`)                                                                          |
-| `--disable-opentela`        |                      | Disable OpenTela wrapper                                                                                                       |
-| `--opentela-bootstrap-addr` |                      | Override the OpenTela bootstrap peer (full multiaddr)                                                                          |
-| `--dev`                     |                      | Shorthand for the dev OpenTela bootstrap peer                                                                                  |
-| `--disable-metrics`         |                      | Disable vmagent metrics push                                                                                                   |
-| `--disable-dcgm-exporter`   |                      | Disable DCGM GPU metrics exporter                                                                                              |
-| `--pre-launch-cmds`         |                      | Shell commands to run before the framework starts                                                                              |
-| `--output-script DIR`       |                      | Render master.sh + rank scripts into DIR and exit (no submit)                                                                  |
+| `--authorization`           | `SML_AUTHORIZATION`  | Who may list and use the model: `public` (default), `private`, or a comma-separated email list — see [Model authorization](#model-authorization)                                                  |
+| `--router`                  |                      | Routing: `opentela` (default) or `sglang` (in-job router, replicas > 1)                                                                                                                           |
+| `--router-args`             |                      | Arguments forwarded to the router (`--router sglang`)                                                                                                                                             |
+| `--disable-opentela`        |                      | Disable OpenTela wrapper                                                                                                                                                                          |
+| `--opentela-bootstrap-addr` |                      | Override the OpenTela bootstrap peer (full multiaddr)                                                                                                                                             |
+| `--dev`                     |                      | Shorthand for the dev OpenTela bootstrap peer                                                                                                                                                     |
+| `--disable-metrics`         |                      | Disable vmagent metrics push                                                                                                                                                                      |
+| `--disable-dcgm-exporter`   |                      | Disable DCGM GPU metrics exporter                                                                                                                                                                 |
+| `--pre-launch-cmds`         |                      | Shell commands to run before the framework starts                                                                                                                                                 |
+| `--output-script DIR`       |                      | Render master.sh + rank scripts into DIR and exit (no submit)                                                                                                                                     |
 
 > Total nodes is `--replicas × --nodes-per-replica`. The framework HTTP port is **8080**.
 
@@ -55,6 +56,45 @@ sml advanced \
 > **Note:** A model named `swiss-ai/Apertus-8B-Instruct-2509` is usually already running — but you won't collide with it. SML prepends your cluster username, so the example above is served as `<your-username>/swiss-ai/Apertus-8B-Instruct-2509`, and that is the id to send in the `model` field. Write the name without a namespace and let SML add it; passing a name under another user's namespace is rejected before the job is submitted.
 
 For more ready-to-run scripts per cluster and vendor, see [`examples/`](https://github.com/swiss-ai/model-launch/tree/main/examples).
+
+## Model authorization
+
+By default a launched model is **public**: anyone can see it in the model list at
+<https://serving.swissai.svc.cscs.ch> and send it inference requests. `--authorization`
+narrows that down:
+
+```bash
+sml advanced ... --authorization public                        # anyone (default)
+sml advanced ... --authorization private                       # only you
+sml advanced ... --authorization user1@epfl.ch,user2@ethz.ch   # only these users
+```
+
+The policy is attached to the job as an OpenTela peer label, and the Serving API
+enforces it in two places: `/v1/models` hides models you may not use, and every
+inference route answers `403` if you are not on the list. It lives and dies with the
+job — there is nothing to clean up when the model goes away, and changing the policy
+means relaunching.
+
+A few things worth knowing:
+
+- **The email list is literal.** `--authorization user1@epfl.ch` means *that user
+  only* — it does not implicitly include you. That is what lets you hand a model to a
+  collaborator, and also how you lock yourself out.
+- **`private` is resolved before submission.** The mesh has no notion of who launched
+  a job, so SML swaps `private` for your own email by asking the Serving API's
+  `/v1/whoami` with your Swiss AI Research API key (from `sml init`). Without a
+  working key, a `private` launch stops rather than falling back to public.
+- **Emails are the ones the Serving API knows you by** — the address you log in with,
+  which is the owner of your API key. Case and spacing don't matter.
+- **One name, one policy.** OpenTela load-balances a served name across every peer
+  advertising it, so if two launches share a name with *different* policies, the
+  gateway refuses to route that name for everyone until the conflict is gone. Served
+  names are namespaced under your username, so the realistic way to hit this is
+  relaunching your own model with a new policy while the old job is still up — SML
+  checks for it and refuses to submit rather than taking down the running model.
+- **Labels are self-asserted.** This is access control at the gateway, not
+  authentication on the mesh: anyone able to join the mesh can claim any label. Treat
+  it as "who is this model *for*", not as a security boundary against a hostile peer.
 
 ## Running past the 12 h cap (`--consecutive`)
 

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -48,12 +48,14 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509 \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509 \
     --host 0.0.0.0 \
     --enable-metrics"
 ```
 
-> **Note:** A model named `swiss-ai/Apertus-8B-Instruct-2509` is usually already running — but you won't collide with it. SML prepends your cluster username, so the example above is served as `<your-username>/swiss-ai/Apertus-8B-Instruct-2509`, and that is the id to send in the `model` field. Write the name without a namespace and let SML add it; passing a name under another user's namespace is rejected before the job is submitted.
+> **Note:** Served names are namespaced under your cluster account — `<your-username>/<vendor>/<model>` — so although a model named `swiss-ai/Apertus-8B-Instruct-2509` is usually already running, you won't collide with it. The examples write that namespace out as `$USER/...`, and the expanded name is the id to send in the `model` field.
+>
+> `$USER` has to be your **cluster** account. It normally is, but if you run `sml` from a laptop whose local username differs from your CSCS one, the launch is rejected — the name would be namespaced under someone else. In that case pass `--served-model-name <your-cscs-user>/<vendor>/<model>` explicitly, or omit the namespace entirely and let SML prepend the right one. A name under another user's namespace is always rejected before submission.
 
 For more ready-to-run scripts per cluster and vendor, see [`examples/`](https://github.com/swiss-ai/model-launch/tree/main/examples).
 
@@ -111,7 +113,7 @@ sml advanced \
   --time 36:00:00 \
   --consecutive \
   --framework-args "--model-path /capstor/.../Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509 \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509 \
     --host 0.0.0.0 --enable-metrics"
 ```
 
@@ -170,7 +172,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/.../Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509 \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509 \
     --host 0.0.0.0 --enable-metrics" \
   --output-script /tmp/debug
 ```

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -48,12 +48,14 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509 \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509 \
     --host 0.0.0.0 \
     --enable-metrics"
 ```
 
-> **Note:** A model named `swiss-ai/Apertus-8B-Instruct-2509` is usually already running — but you won't collide with it. SML prepends your cluster username, so the example above is served as `<your-username>/swiss-ai/Apertus-8B-Instruct-2509`, and that is the id to send in the `model` field. Write the name without a namespace and let SML add it; passing a name under another user's namespace is rejected before the job is submitted.
+> **Note:** Served names are namespaced under your cluster account — `<your-username>/<vendor>/<model>` — so although a model named `swiss-ai/Apertus-8B-Instruct-2509` is usually already running, you won't collide with it. The examples write that namespace out as `$USER/...`, and the expanded name is the id to send in the `model` field.
+>
+> `$USER` has to be your **cluster** account. It normally is, but if you run `sml` from a laptop whose local username differs from your CSCS one, the launch is rejected — the name would be namespaced under someone else. In that case pass `--served-model-name <your-cscs-user>/<vendor>/<model>` explicitly, or omit the namespace entirely and let SML prepend the right one. A name under another user's namespace is always rejected before submission.
 
 For more ready-to-run scripts per cluster and vendor, see [`examples/`](https://github.com/swiss-ai/model-launch/tree/main/examples).
 
@@ -111,7 +113,7 @@ sml advanced \
   --time 36:00:00 \
   --consecutive \
   --framework-args "--model-path /capstor/.../Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509 \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509 \
     --host 0.0.0.0 --enable-metrics"
 ```
 
@@ -192,7 +194,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/.../Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509 \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509 \
     --host 0.0.0.0 --enable-metrics" \
   --output-script /tmp/debug
 ```

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -10,31 +10,32 @@ For the guided flow with a curated catalog, use [`sml`](usage-sml.md).
 
 ## Arguments
 
-| Argument                    | Environment Variable | Description                                                                                                                    |
-| --------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `--system`                  | `SML_SYSTEM`         | Target HPC system                                                                                                              |
-| `--partition`               | `SML_PARTITION`      | SLURM partition                                                                                                                |
-| `--account`                 | `SML_ACCOUNT`        | SLURM account used for job submission                                                                                          |
-| `--reservation`             | `SML_RESERVATION`    | SLURM reservation (optional)                                                                                                   |
-| `--framework`               |                      | Inference framework (`sglang`, `vllm`) — **required**                                                                          |
-| `--environment`             |                      | Local path to the environment `.toml` file — **required**                                                                      |
-| `--framework-args`          |                      | Arguments forwarded to the inference framework                                                                                 |
-| `--replicas`                |                      | Number of replicas (default: `1`)                                                                                              |
-| `--nodes-per-replica`       |                      | Nodes per replica (default: `1`)                                                                                               |
-| `--time`                    |                      | Total uptime `HH:MM:SS` (default: `02:00:00`)                                                                                  |
-| `--consecutive`             |                      | Serve a `--time` longer than the per-job cap with a chain of jobs                                                              |
-| `--handover-time`           |                      | Overlap before the previous job ends (default: `03:00:00`)                                                                     |
-| `--max-job-time`            |                      | Per-job cap for chains `HH:MM:SS` (default: `12:00:00`)                                                                        |
-| `--served-model-name`       |                      | Required: here, or `--served-model-name <name>` inside `--framework-args`. Namespaced — see the note below.                    |
-| `--router`                  |                      | Routing: `opentela` (default) or `sglang` (in-job router, replicas > 1)                                                        |
-| `--router-args`             |                      | Arguments forwarded to the router (`--router sglang`)                                                                          |
-| `--disable-opentela`        |                      | Disable OpenTela wrapper                                                                                                       |
-| `--opentela-bootstrap-addr` |                      | Override the OpenTela bootstrap peer (full multiaddr)                                                                          |
-| `--dev`                     |                      | Shorthand for the dev OpenTela bootstrap peer                                                                                  |
-| `--disable-metrics`         |                      | Disable vmagent metrics push                                                                                                   |
-| `--disable-dcgm-exporter`   |                      | Disable DCGM GPU metrics exporter                                                                                              |
-| `--pre-launch-cmds`         |                      | Shell commands to run before the framework starts                                                                              |
-| `--output-script DIR`       |                      | Render master.sh + rank scripts into DIR and exit (no submit)                                                                  |
+| Argument                    | Environment Variable | Description                                                                                                                                                                                       |
+| --------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--system`                  | `SML_SYSTEM`         | Target HPC system                                                                                                                                                                                 |
+| `--partition`               | `SML_PARTITION`      | SLURM partition                                                                                                                                                                                   |
+| `--account`                 | `SML_ACCOUNT`        | SLURM account used for job submission                                                                                                                                                             |
+| `--reservation`             | `SML_RESERVATION`    | SLURM reservation (optional)                                                                                                                                                                      |
+| `--framework`               |                      | Inference framework (`sglang`, `vllm`) — **required**                                                                                                                                             |
+| `--environment`             |                      | Local path to the environment `.toml` file — **required**                                                                                                                                         |
+| `--framework-args`          |                      | Arguments forwarded to the inference framework                                                                                                                                                    |
+| `--replicas`                |                      | Number of replicas (default: `1`)                                                                                                                                                                 |
+| `--nodes-per-replica`       |                      | Nodes per replica (default: `1`)                                                                                                                                                                  |
+| `--time`                    |                      | Total uptime `HH:MM:SS` (default: `02:00:00`)                                                                                                                                                     |
+| `--consecutive`             |                      | Serve a `--time` longer than the per-job cap with a chain of jobs                                                                                                                                 |
+| `--handover-time`           |                      | Overlap before the previous job ends (default: `03:00:00`)                                                                                                                                        |
+| `--max-job-time`            |                      | Per-job cap for chains `HH:MM:SS` (default: `12:00:00`)                                                                                                                                           |
+| `--served-model-name`       |                      | Required: pass it here, or include `--served-model-name <name>` inside `--framework-args`. Omitting both aborts with an error. Namespaced under your username automatically — see the note below. |
+| `--authorization`           | `SML_AUTHORIZATION`  | Who may list and use the model: `public` (default), `private`, or a comma-separated email list — see [Model authorization](#model-authorization)                                                  |
+| `--router`                  |                      | Routing: `opentela` (default) or `sglang` (in-job router, replicas > 1)                                                                                                                           |
+| `--router-args`             |                      | Arguments forwarded to the router (`--router sglang`)                                                                                                                                             |
+| `--disable-opentela`        |                      | Disable OpenTela wrapper                                                                                                                                                                          |
+| `--opentela-bootstrap-addr` |                      | Override the OpenTela bootstrap peer (full multiaddr)                                                                                                                                             |
+| `--dev`                     |                      | Shorthand for the dev OpenTela bootstrap peer                                                                                                                                                     |
+| `--disable-metrics`         |                      | Disable vmagent metrics push                                                                                                                                                                      |
+| `--disable-dcgm-exporter`   |                      | Disable DCGM GPU metrics exporter                                                                                                                                                                 |
+| `--pre-launch-cmds`         |                      | Shell commands to run before the framework starts                                                                                                                                                 |
+| `--output-script DIR`       |                      | Render master.sh + rank scripts into DIR and exit (no submit)                                                                                                                                     |
 
 > Total nodes is `--replicas × --nodes-per-replica`. The framework HTTP port is **8080**.
 
@@ -55,6 +56,45 @@ sml advanced \
 > **Note:** A model named `swiss-ai/Apertus-8B-Instruct-2509` is usually already running — but you won't collide with it. SML prepends your cluster username, so the example above is served as `<your-username>/swiss-ai/Apertus-8B-Instruct-2509`, and that is the id to send in the `model` field. Write the name without a namespace and let SML add it; passing a name under another user's namespace is rejected before the job is submitted.
 
 For more ready-to-run scripts per cluster and vendor, see [`examples/`](https://github.com/swiss-ai/model-launch/tree/main/examples).
+
+## Model authorization
+
+By default a launched model is **public**: anyone can see it in the model list at
+<https://serving.swissai.svc.cscs.ch> and send it inference requests. `--authorization`
+narrows that down:
+
+```bash
+sml advanced ... --authorization public                        # anyone (default)
+sml advanced ... --authorization private                       # only you
+sml advanced ... --authorization user1@epfl.ch,user2@ethz.ch   # only these users
+```
+
+The policy is attached to the job as an OpenTela peer label, and the Serving API
+enforces it in two places: `/v1/models` hides models you may not use, and every
+inference route answers `403` if you are not on the list. It lives and dies with the
+job — there is nothing to clean up when the model goes away, and changing the policy
+means relaunching.
+
+A few things worth knowing:
+
+- **The email list is literal.** `--authorization user1@epfl.ch` means *that user
+  only* — it does not implicitly include you. That is what lets you hand a model to a
+  collaborator, and also how you lock yourself out.
+- **`private` is resolved before submission.** The mesh has no notion of who launched
+  a job, so SML swaps `private` for your own email by asking the Serving API's
+  `/v1/whoami` with your Swiss AI Research API key (from `sml init`). Without a
+  working key, a `private` launch stops rather than falling back to public.
+- **Emails are the ones the Serving API knows you by** — the address you log in with,
+  which is the owner of your API key. Case and spacing don't matter.
+- **One name, one policy.** OpenTela load-balances a served name across every peer
+  advertising it, so if two launches share a name with *different* policies, the
+  gateway refuses to route that name for everyone until the conflict is gone. Served
+  names are namespaced under your username, so the realistic way to hit this is
+  relaunching your own model with a new policy while the old job is still up — SML
+  checks for it and refuses to submit rather than taking down the running model.
+- **Labels are self-asserted.** This is access control at the gateway, not
+  authentication on the mesh: anyone able to join the mesh can claim any label. Treat
+  it as "who is this model *for*", not as a security boundary against a hostile peer.
 
 ## Running past the 12 h cap (`--consecutive`)
 

--- a/docs/usage-sml.md
+++ b/docs/usage-sml.md
@@ -12,23 +12,24 @@ After [initialization](initialization.md):
 sml
 ```
 
-You'll be prompted for: target system (FirecREST only), partition, SLURM reservation (optional, blank to skip), SLURM account (optional, blank for your default group), model, framework, replica count, routing strategy (only when replica count > 1), and time limit. SML submits the job and the TUI takes over.
+You'll be prompted for: target system (FirecREST only), partition, SLURM reservation (optional, blank to skip), SLURM account (optional, blank for your default group), model, framework, replica count, routing strategy (only when replica count > 1), time limit, and who may use the model ([authorization](usage-advanced.md#model-authorization) — `public` by default). SML submits the job and the TUI takes over.
 
 ## Skipping the prompts
 
 You can pre-fill any prompt with a CLI flag or environment variable. Whatever you don't supply, SML asks for.
 
-| Argument        | Environment Variable | Description                                              |
-| --------------- | -------------------- | -------------------------------------------------------- |
-| `--system`      | `SML_SYSTEM`         | Target system (required if launcher is `firecrest`)      |
-| `--partition`   | `SML_PARTITION`      | SLURM partition                                          |
-| `--reservation` | `SML_RESERVATION`    | SLURM reservation (optional)                             |
-| `--account`     | `SML_ACCOUNT`        | SLURM account used for job submission (optional)         |
-| `--model`       |                      | Model to launch (`<vendor>/<model>`)                     |
-| `--framework`   |                      | Inference framework                                      |
-| `--replicas`    |                      | Number of replicas                                       |
-| `--router`      |                      | Routing strategy across replicas (`opentela` / `sglang`) |
-| `--time`        |                      | Job time limit (`HH:MM:SS`)                              |
+| Argument          | Environment Variable | Description                                                                                                                                        |
+| ----------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--system`        | `SML_SYSTEM`         | Target system (required if launcher is `firecrest`)                                                                                                |
+| `--partition`     | `SML_PARTITION`      | SLURM partition                                                                                                                                    |
+| `--reservation`   | `SML_RESERVATION`    | SLURM reservation (optional)                                                                                                                       |
+| `--account`       | `SML_ACCOUNT`        | SLURM account used for job submission (optional)                                                                                                   |
+| `--model`         |                      | Model to launch (`<vendor>/<model>`)                                                                                                               |
+| `--framework`     |                      | Inference framework                                                                                                                                |
+| `--replicas`      |                      | Number of replicas                                                                                                                                 |
+| `--router`        |                      | Routing strategy across replicas (`opentela` / `sglang`)                                                                                           |
+| `--time`          |                      | Job time limit (`HH:MM:SS`)                                                                                                                        |
+| `--authorization` | `SML_AUTHORIZATION`  | Who may list and use the model: `public` (default), `private`, or an email list — see [Model authorization](usage-advanced.md#model-authorization) |
 
 CLI flags take precedence over environment variables.
 

--- a/examples/beverin/cli/swiss-ai/Apertus-70B-Instruct-2509-sglang-rocm.sh
+++ b/examples/beverin/cli/swiss-ai/Apertus-70B-Instruct-2509-sglang-rocm.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time "12:00:00" \
   --partition mi300 \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-70B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang \
     --host 0.0.0.0 \
     --tp-size 4 \
     --mem-fraction-static 0.5 \

--- a/examples/beverin/cli/swiss-ai/Apertus-70B-Instruct-2509-vllm-rocm.sh
+++ b/examples/beverin/cli/swiss-ai/Apertus-70B-Instruct-2509-vllm-rocm.sh
@@ -6,6 +6,6 @@ sml advanced \
   --time "12:00:00" \
   --partition mi300 \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-70B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm \
     --host 0.0.0.0 \
     --tensor-parallel-size 4 --gpu-memory-utilization 0.85"

--- a/examples/beverin/cli/swiss-ai/Apertus-8B-Instruct-2509-vllm-rocm.sh
+++ b/examples/beverin/cli/swiss-ai/Apertus-8B-Instruct-2509-vllm-rocm.sh
@@ -6,6 +6,6 @@ sml advanced \
   --time "05:00:00" \
   --partition mi300 \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509-rocm \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509-rocm \
     --host 0.0.0.0 \
     --gpu-memory-utilization 0.5"

--- a/examples/beverin/cli/swiss-ai/experiment-rocm-memory/rocm-memory-experiment.sh
+++ b/examples/beverin/cli/swiss-ai/experiment-rocm-memory/rocm-memory-experiment.sh
@@ -13,7 +13,7 @@ sml advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model $MODEL \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-mem-fraction-05 \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-mem-fraction-05 \
     --host 0.0.0.0 --tp-size 4 \
     --mem-fraction-static 0.5"
 
@@ -25,7 +25,7 @@ sml advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model $MODEL \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-delete-ckpt \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-delete-ckpt \
     --host 0.0.0.0 --tp-size 4 \
     --delete-ckpt-after-loading"
 
@@ -37,7 +37,7 @@ sml advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model $MODEL \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-disable-mmap \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-disable-mmap \
     --host 0.0.0.0 --tp-size 4 \
     --weight-loader-disable-mmap"
 
@@ -49,7 +49,7 @@ sml advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model $MODEL \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-disable-mmap-mem-fraction-05 \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-disable-mmap-mem-fraction-05 \
     --host 0.0.0.0 --tp-size 4 \
     --weight-loader-disable-mmap \
     --mem-fraction-static 0.5"
@@ -62,7 +62,7 @@ sml advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model $MODEL \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-disable-mmap-mem-fraction \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-disable-mmap-mem-fraction \
     --host 0.0.0.0 --tp-size 4 \
     --weight-loader-disable-mmap \
     --mem-fraction-static 0.7"
@@ -75,7 +75,7 @@ sml advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model $MODEL \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-disable-mmap-delete-ckpt-mem-fraction \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-disable-mmap-delete-ckpt-mem-fraction \
     --host 0.0.0.0 --tp-size 4 \
     --weight-loader-disable-mmap \
     --delete-ckpt-after-loading \
@@ -90,7 +90,7 @@ sml advanced \
   --environment "$ENV" \
   --pre-launch-cmds "pip install torch-memory-saver" \
   --framework-args "--model $MODEL \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-mem-saver \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-mem-saver \
     --host 0.0.0.0 --tp-size 4 \
     --enable-memory-saver"
 
@@ -103,7 +103,7 @@ sml advanced \
   --environment "$ENV" \
   --pre-launch-cmds "pip install torch-memory-saver" \
   --framework-args "--model $MODEL \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-all-mem-opts \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-all-mem-opts \
     --host 0.0.0.0 --tp-size 4 \
     --enable-memory-saver \
     --delete-ckpt-after-loading \
@@ -118,6 +118,6 @@ sml advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model $MODEL \
-    --served-model-name swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-2nodes \
+    --served-model-name $USER/swiss-ai/Apertus-70B-Instruct-2509-rocm-sglang-2nodes \
     --host 0.0.0.0 --tp-size 8 \
     --mem-fraction-static 0.5"

--- a/examples/beverin/python/launch_apertus_8b_sglang_rocm.py
+++ b/examples/beverin/python/launch_apertus_8b_sglang_rocm.py
@@ -22,14 +22,14 @@ async def main() -> None:
 
     args = LaunchArgs(
         job_name=f"sml_apertus_8b_rocm_{username}",
-        served_model_name=f"swiss-ai/Apertus-8B-Instruct-2509-sglang-rocm-{username}",
+        served_model_name=f"{username}/swiss-ai/Apertus-8B-Instruct-2509-sglang-rocm",
         account=account,
         partition="mi300",
         environment="src/swiss_ai_model_launch/assets/envs/sglang_rocm.toml",
         framework="sglang",
         framework_args=(
             "--model /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-8B-Instruct-2509 "
-            f"--served-model-name swiss-ai/Apertus-8B-Instruct-2509-sglang-rocm-{username} "
+            f"--served-model-name {username}/swiss-ai/Apertus-8B-Instruct-2509-sglang-rocm "
             "--host 0.0.0.0 "
             "--tp-size 4 "
             "--mem-fraction-static 0.15 "

--- a/examples/beverin/python/launch_apertus_8b_vllm_rocm.py
+++ b/examples/beverin/python/launch_apertus_8b_vllm_rocm.py
@@ -22,14 +22,14 @@ async def main() -> None:
 
     args = LaunchArgs(
         job_name=f"sml_apertus_8b_vllm_rocm_{username}",
-        served_model_name=f"swiss-ai/Apertus-8B-Instruct-2509-vllm-rocm-{username}",
+        served_model_name=f"{username}/swiss-ai/Apertus-8B-Instruct-2509-vllm-rocm",
         account=account,
         partition="mi300",
         environment="src/swiss_ai_model_launch/assets/envs/vllm_rocm.toml",
         framework="vllm",
         framework_args=(
             "--model /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-8B-Instruct-2509 "
-            f"--served-model-name swiss-ai/Apertus-8B-Instruct-2509-vllm-rocm-{username} "
+            f"--served-model-name {username}/swiss-ai/Apertus-8B-Instruct-2509-vllm-rocm "
             "--host 0.0.0.0 "
             "--tensor-parallel-size 4 "
             "--gpu-memory-utilization 0.5"

--- a/examples/bristen/cli/swiss-ai/Apertus-8B-Instruct-2509-sglang.sh
+++ b/examples/bristen/cli/swiss-ai/Apertus-8B-Instruct-2509-sglang.sh
@@ -5,6 +5,6 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang_bristen.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509 \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509 \
     --host 0.0.0.0 \
     --enable-metrics"

--- a/examples/clariden/cli/allenai/Olmo-3.1-32B-Instruct-sglang.sh
+++ b/examples/clariden/cli/allenai/Olmo-3.1-32B-Instruct-sglang.sh
@@ -6,5 +6,5 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/allenai/Olmo-3.1-32B-Instruct \
     --host 0.0.0.0 \
-    --served-model-name allenai/Olmo-3.1-32B-Instruct \
+    --served-model-name $USER/allenai/Olmo-3.1-32B-Instruct \
     --tp-size 4"

--- a/examples/clariden/cli/arcee-ai/Trinity-Mini-vllm.sh
+++ b/examples/clariden/cli/arcee-ai/Trinity-Mini-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/arcee-ai/Trinity-Mini \
-    --served-model-name arcee-ai/Trinity-Mini \
+    --served-model-name $USER/arcee-ai/Trinity-Mini \
     --host 0.0.0.0 \
     --enable-auto-tool-choice \
     --reasoning-parser deepseek_r1 \

--- a/examples/clariden/cli/arcee-ai/Trinity-Nano-Preview-vllm.sh
+++ b/examples/clariden/cli/arcee-ai/Trinity-Nano-Preview-vllm.sh
@@ -5,6 +5,6 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/arcee-ai/Trinity-Nano-Preview \
-    --served-model-name arcee-ai/Trinity-Nano-Preview \
+    --served-model-name $USER/arcee-ai/Trinity-Nano-Preview \
     --host 0.0.0.0 \
     "

--- a/examples/clariden/cli/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-sglang.sh
+++ b/examples/clariden/cli/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-sglang.sh
@@ -6,6 +6,6 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B \
     --host 0.0.0.0 \
-    --served-model-name deepseek-ai/DeepSeek-R1-Distill-Qwen-32B \
+    --served-model-name $USER/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B \
     --tp-size 4 \
     --reasoning-parser deepseek-r1"

--- a/examples/clariden/cli/deepseek-ai/DeepSeek-V3.1-sglang-router.sh
+++ b/examples/clariden/cli/deepseek-ai/DeepSeek-V3.1-sglang-router.sh
@@ -8,7 +8,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/deepseek-ai/DeepSeek-V3.1 \
-    --served-model-name deepseek-ai/DeepSeek-V3.1 \
+    --served-model-name $USER/deepseek-ai/DeepSeek-V3.1 \
     --tp-size 16 \
     --host 0.0.0.0 \
     --enable-metrics"

--- a/examples/clariden/cli/deepseek-ai/DeepSeek-V3.1-sglang.sh
+++ b/examples/clariden/cli/deepseek-ai/DeepSeek-V3.1-sglang.sh
@@ -6,7 +6,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/deepseek-ai/DeepSeek-V3.1 \
-    --served-model-name deepseek-ai/DeepSeek-V3.1 \
+    --served-model-name $USER/deepseek-ai/DeepSeek-V3.1 \
     --tp-size 16 \
     --host 0.0.0.0 \
     --enable-metrics"

--- a/examples/clariden/cli/deepseek-ai/DeepSeek-V4-Flash-vllm.sh
+++ b/examples/clariden/cli/deepseek-ai/DeepSeek-V4-Flash-vllm.sh
@@ -7,7 +7,7 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/deepseek-ai/DeepSeek-V4-Flash \
     --host 0.0.0.0 \
-    --served-model-name deepseek-ai/DeepSeek-V4-Flash \
+    --served-model-name $USER/deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
     --block-size 256 \

--- a/examples/clariden/cli/google/gemma-3-27b-it-vllm.sh
+++ b/examples/clariden/cli/google/gemma-3-27b-it-vllm.sh
@@ -5,6 +5,6 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/google/gemma-3-27b-it \
-    --served-model-name google/gemma-3-27b-it \
+    --served-model-name $USER/google/gemma-3-27b-it \
     --host 0.0.0.0 \
     --tensor-parallel-size 4"

--- a/examples/clariden/cli/google/gemma-4-31B-it-vllm.sh
+++ b/examples/clariden/cli/google/gemma-4-31B-it-vllm.sh
@@ -5,6 +5,6 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/google/gemma-4-31B-it \
-    --served-model-name google/gemma-4-31B-it \
+    --served-model-name $USER/google/gemma-4-31B-it \
     --host 0.0.0.0 \
     --tensor-parallel-size 4"

--- a/examples/clariden/cli/google/gemma-4-E2B-it-vllm.sh
+++ b/examples/clariden/cli/google/gemma-4-E2B-it-vllm.sh
@@ -5,6 +5,6 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/google/gemma-4-E2B-it \
-    --served-model-name google/gemma-4-E2B-it \
+    --served-model-name $USER/google/gemma-4-E2B-it \
     --host 0.0.0.0 \
     --data-parallel-size 4"

--- a/examples/clariden/cli/google/gemma-4-E4B-it-vllm.sh
+++ b/examples/clariden/cli/google/gemma-4-E4B-it-vllm.sh
@@ -5,6 +5,6 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/google/gemma-4-E4B-it \
-    --served-model-name google/gemma-4-E4B-it \
+    --served-model-name $USER/google/gemma-4-E4B-it \
     --host 0.0.0.0 \
     --data-parallel-size 4"

--- a/examples/clariden/cli/huggingface/SmolLM3-3B-sglang.sh
+++ b/examples/clariden/cli/huggingface/SmolLM3-3B-sglang.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/HuggingFaceTB/SmolLM3-3B \
-    --served-model-name HuggingFaceTB/SmolLM3-3B \
+    --served-model-name $USER/HuggingFaceTB/SmolLM3-3B \
     --dp-size 4 \
     --host 0.0.0.0 \
     --enable-metrics"

--- a/examples/clariden/cli/mistralai/Ministral-3-14B-Instruct-2512-vllm.sh
+++ b/examples/clariden/cli/mistralai/Ministral-3-14B-Instruct-2512-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/mistralai/Ministral-3-14B-Instruct-2512 \
-    --served-model-name mistralai/Ministral-3-14B-Instruct-2512 \
+    --served-model-name $USER/mistralai/Ministral-3-14B-Instruct-2512 \
     --host 0.0.0.0 \
     --data-parallel-size 4 \
     --tokenizer_mode mistral \

--- a/examples/clariden/cli/mistralai/Ministral-3-3B-Instruct-2512-vllm.sh
+++ b/examples/clariden/cli/mistralai/Ministral-3-3B-Instruct-2512-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/mistralai/Ministral-3-3B-Instruct-2512 \
-    --served-model-name mistralai/Ministral-3-3B-Instruct-2512 \
+    --served-model-name $USER/mistralai/Ministral-3-3B-Instruct-2512 \
     --host 0.0.0.0 \
     --data-parallel-size 4 \
     --tokenizer_mode mistral \

--- a/examples/clariden/cli/mistralai/Ministral-3-8B-Instruct-2512-vllm.sh
+++ b/examples/clariden/cli/mistralai/Ministral-3-8B-Instruct-2512-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/mistralai/Ministral-3-8B-Instruct-2512 \
-    --served-model-name mistralai/Ministral-3-8B-Instruct-2512 \
+    --served-model-name $USER/mistralai/Ministral-3-8B-Instruct-2512 \
     --host 0.0.0.0 \
     --data-parallel-size 4 \
     --tokenizer_mode mistral \

--- a/examples/clariden/cli/mistralai/Mistral-7B-Instruct-v0.1-sglang.sh
+++ b/examples/clariden/cli/mistralai/Mistral-7B-Instruct-v0.1-sglang.sh
@@ -5,6 +5,6 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/mistralai/Mistral-7B-Instruct-v0.1 \
-    --served-model-name mistralai/Mistral-7B-Instruct-v0.1 \
+    --served-model-name $USER/mistralai/Mistral-7B-Instruct-v0.1 \
     --host 0.0.0.0 \
     --enable-metrics"

--- a/examples/clariden/cli/mistralai/Mistral-Large-3-675B-Instruct-2512-vllm.sh
+++ b/examples/clariden/cli/mistralai/Mistral-Large-3-675B-Instruct-2512-vllm.sh
@@ -7,5 +7,5 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/mistralai/Mistral-Large-3-675B-Instruct-2512 \
     --host 0.0.0.0 \
-    --served-model-name mistralai/Mistral-Large-3-675B-Instruct-2512 \
+    --served-model-name $USER/mistralai/Mistral-Large-3-675B-Instruct-2512 \
     --tensor-parallel-size 16"

--- a/examples/clariden/cli/mistralai/Mistral-Small-24B-Instruct-2501-sglang.sh
+++ b/examples/clariden/cli/mistralai/Mistral-Small-24B-Instruct-2501-sglang.sh
@@ -6,6 +6,6 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/mistralai/Mistral-Small-24B-Instruct-2501 \
     --host 0.0.0.0 \
-    --served-model-name mistralai/Mistral-Small-24B-Instruct-2501 \
+    --served-model-name $USER/mistralai/Mistral-Small-24B-Instruct-2501 \
     --dp-size 4 \
     --enable-metrics"

--- a/examples/clariden/cli/mistralai/Mixtral-8x22B-Instruct-v0.1-sglang.sh
+++ b/examples/clariden/cli/mistralai/Mixtral-8x22B-Instruct-v0.1-sglang.sh
@@ -8,5 +8,5 @@ sml advanced \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/mistralai/Mixtral-8x22B-Instruct-v0.1 \
     --host 0.0.0.0 \
     --tp-size 8 \
-    --served-model-name mistralai/Mixtral-8x22B-Instruct-v0.1 \
+    --served-model-name $USER/mistralai/Mixtral-8x22B-Instruct-v0.1 \
     --enable-metrics"

--- a/examples/clariden/cli/moonshotai/Kimi-K2-Instruct-sglang.sh
+++ b/examples/clariden/cli/moonshotai/Kimi-K2-Instruct-sglang.sh
@@ -7,7 +7,7 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang_kimi.toml \
   --pre-launch-cmds "pip install blobfile" \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/moonshotai/Kimi-K2-Instruct \
-    --served-model-name moonshotai/Kimi-K2-Instruct \
+    --served-model-name $USER/moonshotai/Kimi-K2-Instruct \
     --tp-size 16 \
     --host 0.0.0.0 \
     --trust-remote-code \

--- a/examples/clariden/cli/moonshotai/Kimi-K2-Thinking-sglang.sh
+++ b/examples/clariden/cli/moonshotai/Kimi-K2-Thinking-sglang.sh
@@ -7,7 +7,7 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang_kimi.toml \
   --pre-launch-cmds "pip install blobfile" \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/moonshotai/Kimi-K2-Thinking \
-    --served-model-name moonshotai/Kimi-K2-Thinking \
+    --served-model-name $USER/moonshotai/Kimi-K2-Thinking \
     --tp-size 16 \
     --host 0.0.0.0 \
     --trust-remote-code \

--- a/examples/clariden/cli/moonshotai/Kimi-K2.5-sglang.sh
+++ b/examples/clariden/cli/moonshotai/Kimi-K2.5-sglang.sh
@@ -6,7 +6,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang_kimi.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/moonshotai/Kimi-K2.5 \
-    --served-model-name moonshotai/Kimi-K2.5 \
+    --served-model-name $USER/moonshotai/Kimi-K2.5 \
     --tp-size 16 \
     --host 0.0.0.0 \
     --trust-remote-code \

--- a/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
+++ b/examples/clariden/cli/openai/gpt-oss-120b-sglang.sh
@@ -6,7 +6,7 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/openai/gpt-oss-120b \
     --host 0.0.0.0 \
-    --served-model-name openai/gpt-oss-120b \
+    --served-model-name $USER/openai/gpt-oss-120b \
     --tp-size 4 \
     --ep-size 4 \
     --enable-metrics"

--- a/examples/clariden/cli/openai/gpt-oss-20b-sglang.sh
+++ b/examples/clariden/cli/openai/gpt-oss-20b-sglang.sh
@@ -6,6 +6,6 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/openai/gpt-oss-20b \
     --host 0.0.0.0 \
-    --served-model-name openai/gpt-oss-20b \
+    --served-model-name $USER/openai/gpt-oss-20b \
     --dp-size 4 \
     --enable-metrics"

--- a/examples/clariden/cli/qwen/Qwen3-235B-A22B-Instruct-2507-sglang.sh
+++ b/examples/clariden/cli/qwen/Qwen3-235B-A22B-Instruct-2507-sglang.sh
@@ -7,6 +7,6 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/Qwen/Qwen3-235B-A22B-Instruct-2507 \
     --host 0.0.0.0 \
-    --served-model-name Qwen/Qwen3-235B-A22B-Instruct-2507 \
+    --served-model-name $USER/Qwen/Qwen3-235B-A22B-Instruct-2507 \
     --tp-size 8 \
     --enable-metrics"

--- a/examples/clariden/cli/qwen/Qwen3-235B-A22B-Instruct-2507-vllm.sh
+++ b/examples/clariden/cli/qwen/Qwen3-235B-A22B-Instruct-2507-vllm.sh
@@ -7,5 +7,5 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/Qwen/Qwen3-235B-A22B-Instruct-2507 \
     --host 0.0.0.0 \
-    --served-model-name Qwen/Qwen3-235B-A22B-Instruct-2507 \
+    --served-model-name $USER/Qwen/Qwen3-235B-A22B-Instruct-2507 \
     --tensor-parallel-size 8"

--- a/examples/clariden/cli/qwen/Qwen3-32B-sglang.sh
+++ b/examples/clariden/cli/qwen/Qwen3-32B-sglang.sh
@@ -6,6 +6,6 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/Qwen/Qwen3-32B \
     --host 0.0.0.0 \
-    --served-model-name Qwen/Qwen3-32B \
+    --served-model-name $USER/Qwen/Qwen3-32B \
     --tp-size 4 \
     --enable-metrics"

--- a/examples/clariden/cli/qwen/Qwen3-8B-sglang.sh
+++ b/examples/clariden/cli/qwen/Qwen3-8B-sglang.sh
@@ -6,6 +6,6 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/Qwen/Qwen3-8B \
     --host 0.0.0.0 \
-    --served-model-name Qwen/Qwen3-8B \
+    --served-model-name $USER/Qwen/Qwen3-8B \
     --dp-size 4 \
     --enable-metrics"

--- a/examples/clariden/cli/qwen/Qwen3-ASR-1.7B-vllm.sh
+++ b/examples/clariden/cli/qwen/Qwen3-ASR-1.7B-vllm.sh
@@ -6,7 +6,7 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --pre-launch-cmds "pip install librosa audioread" \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/MLLM/audio_asr/Qwen3-ASR-1.7B \
-    --served-model-name Qwen/Qwen3-ASR-1.7B \
+    --served-model-name $USER/Qwen/Qwen3-ASR-1.7B \
     --data-parallel-size 4 \
     --tensor-parallel-size 1 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/qwen/Qwen3-Next-80B-A3B-Instruct-sglang.sh
+++ b/examples/clariden/cli/qwen/Qwen3-Next-80B-A3B-Instruct-sglang.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/Qwen/Qwen3-Next-80B-A3B-Instruct \
-    --served-model-name Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --served-model-name $USER/Qwen/Qwen3-Next-80B-A3B-Instruct \
     --host 0.0.0.0 \
     --tp-size 4 \
     --enable-metrics"

--- a/examples/clariden/cli/qwen/Qwen3-Omni-30B-A3B-Captioner-vllm.sh
+++ b/examples/clariden/cli/qwen/Qwen3-Omni-30B-A3B-Captioner-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
    --framework vllm \
    --environment src/swiss_ai_model_launch/assets/envs/vllm_qwen3_omni.toml \
    --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Qwen/Qwen3-Omni-30B-A3B-Captioner \
-    --served-model-name Qwen/Qwen3-Omni-30B-A3B-Captioner \
+    --served-model-name $USER/Qwen/Qwen3-Omni-30B-A3B-Captioner \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --dtype bfloat16 --max-model-len 32768 --trust-remote-code"

--- a/examples/clariden/cli/qwen/Qwen3.5-397B-A17B-sglang.sh
+++ b/examples/clariden/cli/qwen/Qwen3.5-397B-A17B-sglang.sh
@@ -12,7 +12,7 @@ sml advanced \
     --context-length 262144 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen3_coder \
-    --served-model-name Qwen/Qwen3.5-397B-A17B \
+    --served-model-name $USER/Qwen/Qwen3.5-397B-A17B \
     --enable-metrics" \
   --pre-launch-cmds "pip install nvidia-cudnn-cu12==9.16.0.29"
 

--- a/examples/clariden/cli/qwen/Qwen3.5-397B-A17B-vllm.sh
+++ b/examples/clariden/cli/qwen/Qwen3.5-397B-A17B-vllm.sh
@@ -8,4 +8,4 @@ sml advanced \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/Qwen/Qwen3.5-397B-A17B \
     --host 0.0.0.0 \
     --tensor-parallel-size 16 \
-    --served-model-name Qwen/Qwen3.5-397B-A17B"
+    --served-model-name $USER/Qwen/Qwen3.5-397B-A17B"

--- a/examples/clariden/cli/qwen/Qwen3.6-27B-vllm.sh
+++ b/examples/clariden/cli/qwen/Qwen3.6-27B-vllm.sh
@@ -6,7 +6,7 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/Qwen/Qwen3.6-27B \
     --host 0.0.0.0 \
-    --served-model-name Qwen/Qwen3.6-27B \
+    --served-model-name $USER/Qwen/Qwen3.6-27B \
     --data-parallel-size 2 \
     --tensor-parallel-size 2 \
     --max-model-len 65536 \

--- a/examples/clariden/cli/rednote-hilab/dots.mocr-sglang.sh
+++ b/examples/clariden/cli/rednote-hilab/dots.mocr-sglang.sh
@@ -6,7 +6,7 @@ sml advanced \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/MLLM/OCR/rednote-hilab_dots.mocr \
     --host 0.0.0.0 \
-    --served-model-name dots_mocr \
+    --served-model-name $USER/dots_mocr \
     --dp-size 4 \
     --tp-size 1 \
     --trust-remote-code \

--- a/examples/clariden/cli/snowflake/snowflake-arctic-embed-l-v2.0-vllm.sh
+++ b/examples/clariden/cli/snowflake/snowflake-arctic-embed-l-v2.0-vllm.sh
@@ -5,6 +5,6 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/Snowflake/snowflake-arctic-embed-l-v2.0 \
-    --served-model-name Snowflake/snowflake-arctic-embed-l-v2.0 \
+    --served-model-name $USER/Snowflake/snowflake-arctic-embed-l-v2.0 \
     --host 0.0.0.0 \
     --task embedding"

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-Instruct-Offline-then-Online-DPO.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-Instruct-Offline-then-Online-DPO.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/Alignment/current_newest_models/Offline-then-Online-DPO/ \
-    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct-Offline-then-Online-DPO \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-Instruct-Offline-then-Online-DPO \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-Instruct-vllm.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-Instruct-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/Alignment/trials/apertus-8b-sft-1.5--lr8e-5-MaxMin_4096-Filtered-dpo-lr1e-06-beta25.0-lenNormTrue-ebs128-ep1 \
-    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-Instruct \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-Instruct-vllm.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-Instruct-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/apertus-8b-sft-1.5--lr8e-5-MaxMin_4096-Filtered-dpo-lr1e-06-beta25.0-lenNormTrue-ebs128-ep1 \
-    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-Instruct \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final-nothink.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final-nothink.sh
@@ -6,7 +6,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/Alignment/constitutional_ai/final_8b/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final \
-    --served-model-name swiss-ai/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final-nothink \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final-nothink \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final-think.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final-think.sh
@@ -6,7 +6,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/Alignment/constitutional_ai/final_8b/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final \
-    --served-model-name swiss-ai/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final-think \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback-Final-think \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback.sh
@@ -4,7 +4,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/Alignment/constitutional_ai/final_8b/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback \
-    --served-model-name swiss-ai/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Low-Less-Refuse-Feedback \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Mix-Less-Refuse-Feedback.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Mix-Less-Refuse-Feedback.sh
@@ -4,7 +4,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/Alignment/constitutional_ai/final_8b/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Mix-Less-Refuse-Feedback \
-    --served-model-name swiss-ai/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Mix-Less-Refuse-Feedback \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-SFT-RL-DPO-SDPO-Mix-Less-Refuse-Feedback \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-cooldown-1pct-vision-sft.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-cooldown-1pct-vision-sft.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/sft_in_cooldown_ablation/apertus-1p5-8b-64node-sft-cooldown-1pct-vision-sft/HF \
-    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct-cooldown-1pct-vision-sft \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-Instruct-cooldown-1pct-vision-sft \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-gbs512-mbs1-steps8030-vllm.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-gbs512-mbs1-steps8030-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/MLLM/ablations/apertus-8b-img-SFT-32nodes-gbs512-mbs1-steps8030-img-text-seqlen8192-s2onlytxtloss/HF \
-    --served-model-name swiss-ai/apertus-8b-1.5-gbs512-mbs1-steps8030 \
+    --served-model-name $USER/swiss-ai/apertus-8b-1.5-gbs512-mbs1-steps8030 \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-lr-1e-5-2026-04-23_19-38-55-vllm.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-lr-1e-5-2026-04-23_19-38-55-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /iopsstor/scratch/cscs/hyukhymenko/apertus-sft-runs/ap-1p5-cooldown-sft-21-04-lr-1e-5/2026-04-23_19-38-55/global_step_9688/huggingface \
-    --served-model-name swiss-ai/apertus1p5-lr-1e-5-2026-04-23_19-38-55 \
+    --served-model-name $USER/swiss-ai/apertus1p5-lr-1e-5-2026-04-23_19-38-55 \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-lr-8e-5-2026-04-23_19-08-56-vllm.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-lr-8e-5-2026-04-23_19-08-56-vllm.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /iopsstor/scratch/cscs/hyukhymenko/apertus-sft-runs/ap-1p5-cooldown-sft-21-04-lr-8e-5/2026-04-23_19-08-56/global_step_9688/huggingface \
-    --served-model-name swiss-ai/apertus1p5-lr-8e-5-2026-04-23_19-08-56 \
+    --served-model-name $USER/swiss-ai/apertus1p5-lr-8e-5-2026-04-23_19-08-56 \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_180it.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_180it.sh
@@ -11,7 +11,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/rleval/rl_1p5-8b-stage2_notools_mixthink_1606_180it \
-    --served-model-name swiss-ai/Apertus-1.5-8B-rl-notools_mixthink_1606_180it \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-rl-notools_mixthink_1606_180it \
     --tokenizer /capstor/store/cscs/swissai/infra01/hf_tokenizers/tokenizers/Apertus-v1p5-tool_output_toks-think_toks \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_480it_THINK_and_TOOL.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_480it_THINK_and_TOOL.sh
@@ -11,7 +11,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/rleval/rl_1p5-8b-stage2_notools_mixthink_1606_480it \
-    --served-model-name swiss-ai/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_480it-THINK-TOOL \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_480it-THINK-TOOL \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --trust-remote-code \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-rl-stage2_notools_mixthink_VS_nothink_1606_480it.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-rl-stage2_notools_mixthink_VS_nothink_1606_480it.sh
@@ -12,7 +12,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/rleval/rl_1p5-8b-stage2_notools_mixthink_1606_480it \
-    --served-model-name swiss-ai/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_480it \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_480it \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --trust-remote-code \
@@ -30,7 +30,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/rleval/rl_1p5-8b-stage2_notools_mixthink_1606_480it \
-    --served-model-name swiss-ai/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_480it-THINK \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-rl-stage2_notools_mixthink_1606_480it-THINK \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --trust-remote-code \
@@ -53,7 +53,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/rleval/rl_1p5-8b-stage2_notools_nothink_1606_480it \
-    --served-model-name swiss-ai/Apertus-1.5-8B-rl-stage2_notools_nothink_1606_480it \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-rl-stage2_notools_nothink_1606_480it \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --trust-remote-code \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-rl-step260.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-rl-step260.sh
@@ -10,7 +10,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/rleval/rl_1p5-8b-stage2_notools_nothink_1606_260it \
-    --served-model-name swiss-ai/Apertus-1.5-8B-rl-step260 \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-rl-step260 \
     --tokenizer /capstor/store/cscs/swissai/infra01/hf_tokenizers/tokenizers/Apertus-v1p5-tool_output_toks-think_toks \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-capfilter-constant-it8816.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-capfilter-constant-it8816.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf-checkpoints/Apertus-1p5-8B-sft-capfilter-constant-it8816 \
-    --served-model-name swiss-ai/Apertus-1.5-8B-sft-capfilter-constant-it8816 \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-sft-capfilter-constant-it8816 \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-capfilter-linear-it8816.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-capfilter-linear-it8816.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf-checkpoints/Apertus-1p5-8B-sft-capfilter-linear-it8816 \
-    --served-model-name swiss-ai/Apertus-1.5-8B-sft-capfilter-linear-it8816 \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-sft-capfilter-linear-it8816 \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-capfilter-lr6e-5-constant-innovator-fix-it23409.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-capfilter-lr6e-5-constant-innovator-fix-it23409.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf-checkpoints/Apertus-1p5-8B-sft-capfilter-lr6e-5-constant-innovator-fix-it23409 \
-    --served-model-name swiss-ai/Apertus-1.5-8B-sft-capfilter-lr6e-5-constant-innovator-fix-it23409 \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-sft-capfilter-lr6e-5-constant-innovator-fix-it23409 \
     --tokenizer /capstor/store/cscs/swissai/infra01/MLLM/tokenizer/apertus_emu3.5_instruct \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-dpo.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-dpo.sh
@@ -10,7 +10,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/Alignment/ap_1p5/ap1p5-8b-sft-256k-adam-lr6e-5-constant-128n_4200-online-lr5e-6-beta0.1-bs256-lenNormfalse-maxPL2048-rollout8-images-2453762-2453767 \
-    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct-sft-dpo \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-Instruct-sft-dpo \
     --tokenizer /capstor/store/cscs/swissai/infra01/hf_tokenizers/tokenizers/Apertus-v1p5-tool_output_toks-think_toks \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-long-context-it5800.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-long-context-it5800.sh
@@ -7,7 +7,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-8b-sft-256k-adam-lr6e-5-constant-128n_5800 \
-    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct-LC-5800 \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-Instruct-LC-5800 \
     --tokenizer /capstor/store/cscs/swissai/infra01/hf_tokenizers/tokenizers/Apertus-v1p5-tool_output_toks-think_toks \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-rl-mock.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-rl-mock.sh
@@ -10,7 +10,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/models/rleval/Apertus-1p5-8B-sft-capfilter-linear-it8816_gl_180steps \
-    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct-sft-rl-mock \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-Instruct-sft-rl-mock \
     --tokenizer /capstor/store/cscs/swissai/infra01/hf_tokenizers/tokenizers/Apertus-v1p5-tool_output_toks-think_toks \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-thinking.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft-thinking.sh
@@ -12,7 +12,7 @@ sml advanced \
   --framework vllm \
   --environment /users/ahadinia/repositories/model-launch/src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5_pr173.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-8b-sft-256k-adam-lr6e-5-constant-128n_4200 \
-    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct-sft-think \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-Instruct-sft-think \
     --tokenizer /capstor/store/cscs/swissai/infra01/hf_tokenizers/tokenizers/Apertus-v1p5-tool_output_toks-think_toks \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-1.5-8B-sft.sh
@@ -11,7 +11,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-8b-sft-256k-adam-lr6e-5-constant-128n_4200 \
-    --served-model-name swiss-ai/Apertus-1.5-8B-Instruct-sft \
+    --served-model-name $USER/swiss-ai/Apertus-1.5-8B-Instruct-sft \
     --tokenizer /capstor/store/cscs/swissai/infra01/hf_tokenizers/tokenizers/Apertus-v1p5-tool_output_toks-think_toks \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607-deliberation.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607-deliberation.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-70B-RC \
-    --served-model-name apertus-ai/Apertus-v1.5-70B-RC-deliberation \
+    --served-model-name $USER/apertus-ai/Apertus-v1.5-70B-RC-deliberation \
     --tensor-parallel-size 4 \
     --trust-remote-code \
     --gpu-memory-utilization 0.8 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-70B-RC-2607.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-70B-RC \
-    --served-model-name apertus-ai/Apertus-v1.5-70B-RC-test \
+    --served-model-name $USER/apertus-ai/Apertus-v1.5-70B-RC-test \
     --tensor-parallel-size 4 \
     --skip-mm-profiling \
     --trust-remote-code \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607-deliberation.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607-deliberation.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-8B-RC \
-    --served-model-name apertus-ai/Apertus-v1.5-8B-RC-deliberation \
+    --served-model-name $USER/apertus-ai/Apertus-v1.5-8B-RC-deliberation \
     --skip-mm-profiling \
     --trust-remote-code \
     --gpu-memory-utilization 0.6 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/Apertus-v1.5-8B-RC-2607.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/ahadinia_models/apertus-ai/Apertus-v1.5-8B-RC \
-    --served-model-name apertus-ai/Apertus-v1.5-8B-RC-test \
+    --served-model-name $USER/apertus-ai/Apertus-v1.5-8B-RC-test \
     --skip-mm-profiling \
     --trust-remote-code \
     --gpu-memory-utilization 0.6 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-1800.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-1800.sh
@@ -4,7 +4,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-70b-sft-262k-1800 \
-    --served-model-name swiss-ai/ap1p5-70b-sft-262k-1800 \
+    --served-model-name $USER/swiss-ai/ap1p5-70b-sft-262k-1800 \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-2100.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-2100.sh
@@ -4,7 +4,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-70b-sft-262k-2100 \
-    --served-model-name swiss-ai/ap1p5-70b-sft-262k-2100 \
+    --served-model-name $USER/swiss-ai/ap1p5-70b-sft-262k-2100 \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-2400.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-2400.sh
@@ -4,7 +4,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-70b-sft-262k-2400 \
-    --served-model-name swiss-ai/ap1p5-70b-sft-262k-2400 \
+    --served-model-name $USER/swiss-ai/ap1p5-70b-sft-262k-2400 \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-2700.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-2700.sh
@@ -4,7 +4,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-70b-sft-262k-2700 \
-    --served-model-name swiss-ai/ap1p5-70b-sft-262k-2700 \
+    --served-model-name $USER/swiss-ai/ap1p5-70b-sft-262k-2700 \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \

--- a/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-3000.sh
+++ b/examples/clariden/cli/swiss-ai/1p5-experiments/ap1p5-70b-sft-262k-3000.sh
@@ -4,7 +4,7 @@ sml advanced \
   --framework vllm \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/apertus_1p5/hf_checkpoints/ap1p5-70b-sft-262k-3000 \
-    --served-model-name swiss-ai/ap1p5-70b-sft-262k-3000 \
+    --served-model-name $USER/swiss-ai/ap1p5-70b-sft-262k-3000 \
     --tensor-parallel-size 4 \
     --host 0.0.0.0 \
     --port 8080 \

--- a/examples/clariden/cli/swiss-ai/Apertus-8B-Instruct-2509-sglang.sh
+++ b/examples/clariden/cli/swiss-ai/Apertus-8B-Instruct-2509-sglang.sh
@@ -5,6 +5,6 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-8B-Instruct-2509 \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509 \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509 \
     --host 0.0.0.0 \
     --enable-metrics"

--- a/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-70B-thinking.sh
+++ b/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-70B-thinking.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5_release.toml \
   --framework-args "--model swiss-ai/Apertus-v1.5-70B \
-    --served-model-name swiss-ai/Apertus-v1.5-70B-thinking \
+    --served-model-name $USER/swiss-ai/Apertus-v1.5-70B-thinking \
     --chat-template-content-format string \
     --tensor-parallel-size 4 \
     --gpu-memory-utilization 0.8 \

--- a/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-70B.sh
+++ b/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-70B.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5_release.toml \
   --framework-args "--model swiss-ai/Apertus-v1.5-70B \
-    --served-model-name swiss-ai/Apertus-v1.5-70B \
+    --served-model-name $USER/swiss-ai/Apertus-v1.5-70B \
     --chat-template-content-format string \
     --tensor-parallel-size 4 \
     --gpu-memory-utilization 0.8 \

--- a/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-8B-thinking.sh
+++ b/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-8B-thinking.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5_release.toml \
   --framework-args "--model swiss-ai/Apertus-v1.5-8B \
-    --served-model-name swiss-ai/Apertus-v1.5-8B-thinking \
+    --served-model-name $USER/swiss-ai/Apertus-v1.5-8B-thinking \
     --chat-template-content-format string \
     --gpu-memory-utilization 0.6 \
     --max-model-len 262144 \

--- a/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-8B.sh
+++ b/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-8B.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5_release.toml \
   --framework-args "--model swiss-ai/Apertus-v1.5-8B \
-    --served-model-name swiss-ai/Apertus-v1.5-8B
+    --served-model-name $USER/swiss-ai/Apertus-v1.5-8B
     --chat-template-content-format string \
     --gpu-memory-utilization 0.6 \
     --max-model-len 262144 \

--- a/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-8B.sh
+++ b/examples/clariden/cli/swiss-ai/apertus-ai-1.5-release/Apertus-v1.5-8B.sh
@@ -6,7 +6,7 @@ sml advanced \
   --time 12:00:00 \
   --environment src/swiss_ai_model_launch/assets/envs/vllm_apertus_1.5_release.toml \
   --framework-args "--model swiss-ai/Apertus-v1.5-8B \
-    --served-model-name swiss-ai/Apertus-v1.5-8B \
+    --served-model-name $USER/swiss-ai/Apertus-v1.5-8B \
     --chat-template-content-format string \
     --gpu-memory-utilization 0.6 \
     --max-model-len 262144 \

--- a/examples/clariden/cli/swiss-ai/experiment-loadtest/tp-vs-dp-loadtest-advanced.sh
+++ b/examples/clariden/cli/swiss-ai/experiment-loadtest/tp-vs-dp-loadtest-advanced.sh
@@ -21,7 +21,7 @@ sml loadtest advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model-path $MODEL \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509-tp4-${SUFFIX} \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509-tp4-${SUFFIX} \
     --host 0.0.0.0 --port 8080 \
     --tp-size 4 \
     --enable-metrics" \
@@ -37,7 +37,7 @@ sml loadtest advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model-path $MODEL \
-    --served-model-name swiss-ai/Apertus-8B-Instruct-2509-tp1-dp4-${SUFFIX} \
+    --served-model-name $USER/swiss-ai/Apertus-8B-Instruct-2509-tp1-dp4-${SUFFIX} \
     --host 0.0.0.0 --port 8080 \
     --tp-size 1 --dp-size 4 \
     --enable-metrics" \

--- a/examples/clariden/cli/swiss-ai/experiment-loadtest/tp-vs-dp-loadtest.sh
+++ b/examples/clariden/cli/swiss-ai/experiment-loadtest/tp-vs-dp-loadtest.sh
@@ -35,7 +35,7 @@ OUT_1=$(sml advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model-path $MODEL \
-    --served-model-name $SERVED_1 \
+    --served-model-name $USER/$SERVED_1 \
     --host 0.0.0.0 --port 8080 \
     --tp-size 4 \
     --enable-metrics")
@@ -51,7 +51,7 @@ OUT_2=$(sml advanced \
   --framework sglang \
   --environment "$ENV" \
   --framework-args "--model-path $MODEL \
-    --served-model-name $SERVED_2 \
+    --served-model-name $USER/$SERVED_2 \
     --host 0.0.0.0 --port 8080 \
     --tp-size 1 --dp-size 4 \
     --enable-metrics")

--- a/examples/clariden/cli/utter-project/EuroLLM-1.7B-Instruct-sglang.sh
+++ b/examples/clariden/cli/utter-project/EuroLLM-1.7B-Instruct-sglang.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/utter-project/EuroLLM-1.7B-Instruct \
-    --served-model-name utter-project/EuroLLM-1.7B-Instruct \
+    --served-model-name $USER/utter-project/EuroLLM-1.7B-Instruct \
     --dp-size 4 \
     --host 0.0.0.0 \
     --enable-metrics"

--- a/examples/clariden/cli/utter-project/EuroLLM-22B-Instruct-2512-sglang.sh
+++ b/examples/clariden/cli/utter-project/EuroLLM-22B-Instruct-2512-sglang.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/utter-project/EuroLLM-22B-Instruct-2512 \
-    --served-model-name utter-project/EuroLLM-22B-Instruct-2512 \
+    --served-model-name $USER/utter-project/EuroLLM-22B-Instruct-2512 \
     --dp-size 4 \
     --host 0.0.0.0 \
     --enable-metrics"

--- a/examples/clariden/cli/utter-project/EuroLLM-9B-Instruct-2512-sglang.sh
+++ b/examples/clariden/cli/utter-project/EuroLLM-9B-Instruct-2512-sglang.sh
@@ -5,7 +5,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/utter-project/EuroLLM-9B-Instruct-2512 \
-    --served-model-name utter-project/EuroLLM-9B-Instruct-2512 \
+    --served-model-name $USER/utter-project/EuroLLM-9B-Instruct-2512 \
     --dp-size 4 \
     --host 0.0.0.0 \
     --enable-metrics"

--- a/examples/clariden/cli/zai-org/GLM-4.6-sglang-router.sh
+++ b/examples/clariden/cli/zai-org/GLM-4.6-sglang-router.sh
@@ -11,7 +11,7 @@ sml advanced \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/zai-org/GLM-4.6 \
     --tp-size 16 \
     --host 0.0.0.0 \
-    --served-model-name zai-org/GLM-4.6 \
+    --served-model-name $USER/zai-org/GLM-4.6 \
     --trust-remote-code \
     --tool-call-parser glm45 \
     --reasoning-parser glm45 \

--- a/examples/clariden/cli/zai-org/GLM-4.6-sglang.sh
+++ b/examples/clariden/cli/zai-org/GLM-4.6-sglang.sh
@@ -9,7 +9,7 @@ sml advanced \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/zai-org/GLM-4.6 \
     --tp-size 16 \
     --host 0.0.0.0 \
-    --served-model-name zai-org/GLM-4.6 \
+    --served-model-name $USER/zai-org/GLM-4.6 \
     --trust-remote-code \
     --tool-call-parser glm45 \
     --reasoning-parser glm45 \

--- a/examples/clariden/cli/zai-org/GLM-5-FP8-sglang.sh
+++ b/examples/clariden/cli/zai-org/GLM-5-FP8-sglang.sh
@@ -6,7 +6,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/zai-org/GLM-5-FP8 \
-    --served-model-name zai-org/GLM-5-FP8 \
+    --served-model-name $USER/zai-org/GLM-5-FP8 \
     --tp-size 16 \
     --host 0.0.0.0 \
     --tool-call-parser glm47 \

--- a/examples/clariden/cli/zai-org/GLM-5-sglang.sh
+++ b/examples/clariden/cli/zai-org/GLM-5-sglang.sh
@@ -6,7 +6,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/zai-org/GLM-5 \
-    --served-model-name zai-org/GLM-5 \
+    --served-model-name $USER/zai-org/GLM-5 \
     --tp-size 32 \
     --host 0.0.0.0 \
     --tool-call-parser glm47 \

--- a/examples/clariden/cli/zai-org/GLM-5.1-FP8-sglang.sh
+++ b/examples/clariden/cli/zai-org/GLM-5.1-FP8-sglang.sh
@@ -6,7 +6,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/zai-org/GLM-5.1-FP8 \
-    --served-model-name zai-org/GLM-5.1-FP8 \
+    --served-model-name $USER/zai-org/GLM-5.1-FP8 \
     --tp-size 16 \
     --host 0.0.0.0 \
     --reasoning-parser glm45 \

--- a/examples/clariden/cli/zai-org/GLM-5.1-sglang.sh
+++ b/examples/clariden/cli/zai-org/GLM-5.1-sglang.sh
@@ -6,7 +6,7 @@ sml advanced \
   --framework sglang \
   --environment src/swiss_ai_model_launch/assets/envs/sglang.toml \
   --framework-args "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/zai-org/GLM-5.1 \
-    --served-model-name zai-org/GLM-5.1 \
+    --served-model-name $USER/zai-org/GLM-5.1 \
     --tp-size 32 \
     --host 0.0.0.0 \
     --reasoning-parser glm45 \

--- a/examples/clariden/python/launch_apertus_8b.py
+++ b/examples/clariden/python/launch_apertus_8b.py
@@ -25,14 +25,14 @@ async def main() -> None:
 
     args = LaunchArgs(
         job_name=f"sml_apertus_8b_{username}",
-        served_model_name=f"swiss-ai/Apertus-8B-Instruct-2509-{username}",
+        served_model_name=f"{username}/swiss-ai/Apertus-8B-Instruct-2509",
         account=account,
         partition="normal",
         environment="src/swiss_ai_model_launch/assets/envs/sglang.toml",
         framework="sglang",
         framework_args=(
             "--model-path /capstor/store/cscs/swissai/infra01/hf_models/models/swiss-ai/Apertus-8B-Instruct-2509 "
-            f"--served-model-name swiss-ai/Apertus-8B-Instruct-2509-{username} "
+            f"--served-model-name {username}/swiss-ai/Apertus-8B-Instruct-2509 "
             "--host 0.0.0.0 "
             "--enable-metrics"
         ),

--- a/examples/clariden/python/launch_multiple.py
+++ b/examples/clariden/python/launch_multiple.py
@@ -31,7 +31,10 @@ async def launch_model(launcher: SlurmLauncher, model: dict[str, str | int]) -> 
     username = launcher.username
     vendor = model["vendor"]
     name = model["name"]
-    served = f"{vendor}/{name}-{username}"
+    # Served names are namespaced under the launching account:
+    # <username>/<vendor>/<model>. These build LaunchArgs directly, so
+    # nothing prepends it for us — spell it out.
+    served = f"{username}/{vendor}/{name}"
 
     args = LaunchArgs(
         job_name=f"sml_{name}_{username}",

--- a/src/swiss_ai_model_launch/cli/authorization.py
+++ b/src/swiss_ai_model_launch/cli/authorization.py
@@ -1,0 +1,104 @@
+"""CLI-side handling of ``--authorization``.
+
+Kept out of ``cli/main.py`` so the loadtest subcommand — which submits real
+launches through the same ``advanced`` arguments — can apply the identical
+policy handling without importing main (which imports loadtest).
+"""
+
+import argparse
+import sys
+
+from swiss_ai_model_launch.launchers.authorization import (
+    PRIVATE,
+    PUBLIC,
+    is_private,
+    normalize_authorization,
+    policy_of,
+)
+from swiss_ai_model_launch.serving_api import ServingApiError, served_model_authorizations, whoami
+
+
+def is_valid_authorization(raw: str) -> bool:
+    """Predicate form of ``normalize_authorization``, for the interactive
+    prompt's validator — it needs a bool, not an exception."""
+    try:
+        normalize_authorization(raw)
+    except ValueError:
+        return False
+    return True
+
+
+def requested_from_args(args: argparse.Namespace) -> str:
+    """The raw ``--authorization`` value off a parsed namespace, defaulting to
+    public for namespaces built without the flag (tests, example scripts)."""
+    return getattr(args, "authorization", None) or PUBLIC
+
+
+async def resolve_authorization(requested: str | None, api_key: str) -> str:
+    """A raw authorization value as it will be labelled on the mesh.
+
+    ``private`` is turned into the launcher's own email here — the gateway has
+    no way to know who submitted a job, so "only me" has to be spelled out
+    before submission. Everything else is validated and canonicalized so that
+    two launches meaning the same policy emit the same label string.
+
+    Takes the raw string rather than the argparse namespace because the guided
+    flow collects it through the interactive config chain, not as a flag.
+
+    Raises SystemExit with a readable message rather than a traceback: this is
+    the last thing between the user and a model with the wrong audience.
+    """
+    requested = requested or PUBLIC
+    try:
+        normalized = normalize_authorization(requested)
+    except ValueError as exc:
+        raise SystemExit(f"error: {exc}") from exc
+
+    if not is_private(normalized):
+        return normalized
+
+    try:
+        email = await whoami(api_key)
+    except ServingApiError as exc:
+        raise SystemExit(
+            f"error: authorization {PRIVATE!r} needs your identity from the Serving API, but: {exc}"
+        ) from exc
+    return normalize_authorization(email)
+
+
+async def warn_or_refuse_conflict(api_key: str, served_model_name: str, authorization: str) -> None:
+    """Refuse a launch that would make ``served_model_name`` unroutable.
+
+    OpenTela load-balances a served name across every peer advertising it, so
+    the gateway cannot keep a request off a colliding launch's replicas — when
+    two launches share a name with *different* policies it refuses the name for
+    everyone (serving-api ADR-0001). Since names are namespaced by username,
+    the realistic way to hit this is relaunching your own model under a new
+    policy while the old job is still up; catching it here turns a confusing
+    403-for-everyone into an error at submission time.
+
+    Best effort: the check needs the Serving API, and only sees models this key
+    is allowed to see. If it can't ask, it says so and lets the launch proceed —
+    the gateway remains the authority either way.
+    """
+    try:
+        existing = await served_model_authorizations(api_key, served_model_name)
+    except ServingApiError as exc:
+        print(
+            f"warning: could not check for an authorization conflict on {served_model_name!r}: {exc}",
+            file=sys.stderr,
+        )
+        return
+
+    conflicting = {value for value in existing if policy_of(value) != policy_of(authorization)}
+    if not conflicting:
+        return
+
+    raise SystemExit(
+        f"error: {served_model_name!r} is already served with a different authorization policy "
+        f"({', '.join(sorted(repr(c) for c in conflicting))} vs {authorization!r}).\n"
+        "       The Serving API refuses to route a name whose replicas disagree, so this launch "
+        "would take the running one down with it.\n"
+        "       Cancel the running job first, launch under a different --served-model-name, "
+        "or match its --authorization."
+    )

--- a/src/swiss_ai_model_launch/cli/loadtest.py
+++ b/src/swiss_ai_model_launch/cli/loadtest.py
@@ -9,10 +9,16 @@ from typing import Any, Protocol
 
 import questionary
 
+from swiss_ai_model_launch.cli.authorization import (
+    requested_from_args,
+    resolve_authorization,
+    warn_or_refuse_conflict,
+)
 from swiss_ai_model_launch.cli.configuration import InitConfig
 from swiss_ai_model_launch.cli.healthcheck import check_model_health
 from swiss_ai_model_launch.cli.healthcheck.model_health import ModelHealth
 from swiss_ai_model_launch.launchers import Launcher
+from swiss_ai_model_launch.launchers.authorization import PUBLIC
 from swiss_ai_model_launch.launchers.launch_args import LaunchArgs
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.loadtest.cluster import (
@@ -64,6 +70,7 @@ class _BuildLaunchArgsFromAdvanced(Protocol):
         account: str,
         partition: str,
         telemetry_endpoint: str | None = None,
+        authorization: str = PUBLIC,
     ) -> LaunchArgs: ...
 
 
@@ -480,6 +487,13 @@ async def _run_loadtest_preconfigured(
     launcher = await create_launcher(config, args)
     swissai_research_api_key = config.get_non_none_value("swissai_research_api_key")
     launch_request = await get_launch_request(launcher, args)
+    authorization = await resolve_authorization(launch_request.authorization, swissai_research_api_key)
+    launch_request = launch_request.model_copy(update={"authorization": authorization})
+    await warn_or_refuse_conflict(
+        swissai_research_api_key,
+        str(launch_request.served_model_name),
+        authorization,
+    )
     await _prompt_loadtest_scenario(args)
     loadtest_config = make_loadtest_config(args)
 
@@ -505,13 +519,18 @@ async def _run_loadtest_advanced(
     config = InitConfig.load()
     launcher = await create_launcher(config, args, True)
     swissai_research_api_key = config.get_non_none_value("swissai_research_api_key")
+    # A loadtest launch puts a real model on the mesh, so it carries the same
+    # access policy as any other launch rather than defaulting to public.
+    authorization = await resolve_authorization(requested_from_args(args), swissai_research_api_key)
     launch_args = build_launch_args_from_advanced(
         args,
         username=launcher.username,
         account=launcher.account,
         partition=launcher.partition,
         telemetry_endpoint=config.get_value("telemetry_endpoint"),
+        authorization=authorization,
     )
+    await warn_or_refuse_conflict(swissai_research_api_key, launch_args.served_model_name, authorization)
     loadtest_config = make_loadtest_config(args)
 
     await _submit_and_run_loadtest(

--- a/src/swiss_ai_model_launch/cli/main.py
+++ b/src/swiss_ai_model_launch/cli/main.py
@@ -13,6 +13,12 @@ from typing import Any, cast
 
 import firecrest as f7t
 
+from swiss_ai_model_launch.cli.authorization import (
+    is_valid_authorization,
+    requested_from_args,
+    resolve_authorization,
+    warn_or_refuse_conflict,
+)
 from swiss_ai_model_launch.cli.configuration import InitConfig
 from swiss_ai_model_launch.cli.configuration.models import (
     ChainConfiguration,
@@ -26,6 +32,7 @@ from swiss_ai_model_launch.cli.healthcheck import ReplicaHealthReport, check_mod
 from swiss_ai_model_launch.cli.healthcheck.model_health import ModelHealth
 from swiss_ai_model_launch.cli.loadtest import add_loadtest_parser, run_loadtest_command
 from swiss_ai_model_launch.launchers import FirecRESTLauncher, Launcher, SlurmLauncher
+from swiss_ai_model_launch.launchers.authorization import PRIVATE, PUBLIC, describe
 from swiss_ai_model_launch.launchers.framework import OPENTELA_BOOTSTRAP_ADDR_DEV, render_master, render_rank_scripts
 from swiss_ai_model_launch.launchers.job_status import JobStatus
 from swiss_ai_model_launch.launchers.launch_args import (
@@ -50,6 +57,26 @@ _OptionsFactory = Callable[[], Awaitable[OptionsDict]] | Callable[[GetValueFn], 
 # Shared so the OpenTela router description isn't duplicated across the static
 # parser config and the interactive option factories.
 _OPENTELA_ROUTER_DESC = "OpenTela load-balances across the replica peers on the mesh"
+
+_AUTHORIZATION_HELP = (
+    "Who may list and use the model on the Serving API. "
+    f"'{PUBLIC}' (default): everyone. "
+    f"'{PRIVATE}': only you — SML resolves this to your own email via the Serving API's "
+    "/v1/whoami before submitting, so it needs your Swiss AI Research API key. "
+    "Or a comma-separated email list, e.g. 'user1@epfl.ch,user2@ethz.ch' "
+    "(the list is literal: it does NOT implicitly include you). "
+    f"Env: SML_AUTHORIZATION."
+)
+
+
+def _add_authorization_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--authorization",
+        dest="authorization",
+        default=os.environ.get("SML_AUTHORIZATION", PUBLIC),
+        metavar="POLICY",
+        help=_AUTHORIZATION_HELP,
+    )
 
 
 def _make_firecrest_launcher_config(
@@ -160,6 +187,15 @@ def _make_launch_request_config(
                 validator=lambda v: bool(re.fullmatch(r"[0-9]{1,2}:[0-5][0-9]:[0-5][0-9]", v)),
                 default="03:00:00",
             ),
+            TextConfiguration(
+                name="authorization",
+                prompt=(
+                    f"Who may use the model: '{PUBLIC}' (anyone), '{PRIVATE}' (only you), or comma-separated emails."
+                ),
+                validator=is_valid_authorization,
+                default=PUBLIC,
+                env_var="SML_AUTHORIZATION",
+            ),
         ],
     )
 
@@ -259,6 +295,7 @@ def _add_advanced_launch_arguments(
         default=None,
         help="Name under which the model will be served. Auto-generated if omitted.",
     )
+    _add_authorization_argument(advanced_parser)
     advanced_parser.add_argument(
         "--router",
         dest="router",
@@ -579,6 +616,9 @@ async def _get_launch_request(launcher: Launcher, args: argparse.Namespace | Non
         time=launch_req_config.get_non_none_value("time"),
         served_model_name=namespace_served_model_name(model, launcher.username),
         router=cast(RouterMode, launch_req_config.get_non_none_value("router")),
+        # Still raw here ("public" / "private" / emails): resolving `private`
+        # needs the API key, which only the launch commands hold.
+        authorization=launch_req_config.get_non_none_value("authorization"),
     )
 
 
@@ -760,6 +800,14 @@ async def _run_preconfigured(args: argparse.Namespace) -> None:
     launcher = await _create_launcher(config, args)
     swissai_research_api_key = config.get_non_none_value("swissai_research_api_key")
     launch_request = await _get_launch_request(launcher, args)
+    authorization = await resolve_authorization(launch_request.authorization, swissai_research_api_key)
+    launch_request = launch_request.model_copy(update={"authorization": authorization})
+    await warn_or_refuse_conflict(
+        swissai_research_api_key,
+        cast(str, launch_request.served_model_name),
+        authorization,
+    )
+    print(f"Authorization: {describe(authorization)}")
     launch_coro = launcher.launch_model(launch_request)
     if args.tui:
         await _run_monitor(
@@ -784,6 +832,7 @@ def build_launch_args_from_advanced(
     account: str,
     partition: str,
     telemetry_endpoint: str | None = None,
+    authorization: str = PUBLIC,
 ) -> LaunchArgs:
     """Build a LaunchArgs from a parsed `sml advanced` namespace.
 
@@ -848,6 +897,7 @@ def build_launch_args_from_advanced(
         disable_dcgm_exporter=args.disable_dcgm_exporter,
         disable_metrics=args.disable_metrics,
         telemetry_endpoint=telemetry_endpoint,
+        authorization=authorization,
     )
 
 
@@ -860,13 +910,24 @@ async def _run_advanced(args: argparse.Namespace) -> None:
     launcher = await _create_launcher(config, args, non_interactive=True)
     swissai_research_api_key = config.get_non_none_value("swissai_research_api_key")
 
+    authorization = await resolve_authorization(requested_from_args(args), swissai_research_api_key)
     launch_args = build_launch_args_from_advanced(
         args,
         username=launcher.username,
         account=launcher.account,
         partition=launcher.partition,
         telemetry_endpoint=TELEMETRY_ENDPOINT,
+        authorization=authorization,
     )
+    if not args.output_script:
+        # --output-script only renders scripts; nothing joins the mesh, so
+        # there is no collision to check for (and no reason to need network).
+        await warn_or_refuse_conflict(
+            swissai_research_api_key,
+            launch_args.served_model_name,
+            authorization,
+        )
+        print(f"Authorization: {describe(authorization)}")
 
     # Decide single vs. consecutive chain. --time is the total uptime; a job is
     # capped at --max-job-time, so anything longer needs --consecutive and is

--- a/src/swiss_ai_model_launch/cli/main.py
+++ b/src/swiss_ai_model_launch/cli/main.py
@@ -48,7 +48,7 @@ from swiss_ai_model_launch.launchers.launch_args import (
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.launcher import ScheduledJob
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
-from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
+from swiss_ai_model_launch.launchers.served_name import derive_served_model_name, namespace_served_model_name
 from swiss_ai_model_launch.launchers.topology import Topology
 from swiss_ai_model_launch.launchers.utils import call_with_firecrest_retry, create_salt, render_sbatch_header
 from swiss_ai_model_launch.mcp import mcp as _mcp
@@ -601,7 +601,7 @@ async def _get_launch_request(launcher: Launcher, args: argparse.Namespace | Non
         catalogue_entry,
         replicas=int(launch_req_config.get_non_none_value("replicas")),
         time=launch_req_config.get_non_none_value("time"),
-        served_model_name=namespace_served_model_name(model, launcher.username),
+        served_model_name=derive_served_model_name(model, framework, launcher.username),
         router=cast(RouterMode, launch_req_config.get_non_none_value("router")),
         # Still raw here ("public" / "private" / emails): resolving `private`
         # needs the API key, which only the launch commands hold.

--- a/src/swiss_ai_model_launch/cli/main.py
+++ b/src/swiss_ai_model_launch/cli/main.py
@@ -47,7 +47,7 @@ from swiss_ai_model_launch.launchers.launch_args import (
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.launcher import ScheduledJob
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
-from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
+from swiss_ai_model_launch.launchers.served_name import derive_served_model_name, namespace_served_model_name
 from swiss_ai_model_launch.launchers.topology import Topology
 from swiss_ai_model_launch.launchers.utils import call_with_firecrest_retry, create_salt, render_sbatch_header
 from swiss_ai_model_launch.mcp import mcp as _mcp
@@ -614,7 +614,7 @@ async def _get_launch_request(launcher: Launcher, args: argparse.Namespace | Non
         catalogue_entry,
         replicas=int(launch_req_config.get_non_none_value("replicas")),
         time=launch_req_config.get_non_none_value("time"),
-        served_model_name=namespace_served_model_name(model, launcher.username),
+        served_model_name=derive_served_model_name(model, framework, launcher.username),
         router=cast(RouterMode, launch_req_config.get_non_none_value("router")),
         # Still raw here ("public" / "private" / emails): resolving `private`
         # needs the API key, which only the launch commands hold.

--- a/src/swiss_ai_model_launch/cli/main.py
+++ b/src/swiss_ai_model_launch/cli/main.py
@@ -13,6 +13,12 @@ from typing import Any, cast
 
 import firecrest as f7t
 
+from swiss_ai_model_launch.cli.authorization import (
+    is_valid_authorization,
+    requested_from_args,
+    resolve_authorization,
+    warn_or_refuse_conflict,
+)
 from swiss_ai_model_launch.cli.configuration import InitConfig, optional_value
 from swiss_ai_model_launch.cli.configuration.models import (
     ChainConfiguration,
@@ -26,6 +32,7 @@ from swiss_ai_model_launch.cli.healthcheck import ReplicaHealthReport, check_mod
 from swiss_ai_model_launch.cli.healthcheck.model_health import ModelHealth
 from swiss_ai_model_launch.cli.loadtest import add_loadtest_parser, run_loadtest_command
 from swiss_ai_model_launch.launchers import FirecRESTLauncher, Launcher, SlurmLauncher
+from swiss_ai_model_launch.launchers.authorization import PRIVATE, PUBLIC, describe
 from swiss_ai_model_launch.launchers.firecrest_auth import build_client
 from swiss_ai_model_launch.launchers.framework import OPENTELA_BOOTSTRAP_ADDR_DEV, render_master, render_rank_scripts
 from swiss_ai_model_launch.launchers.job_status import JobStatus
@@ -51,6 +58,26 @@ _OptionsFactory = Callable[[], Awaitable[OptionsDict]] | Callable[[GetValueFn], 
 # Shared so the OpenTela router description isn't duplicated across the static
 # parser config and the interactive option factories.
 _OPENTELA_ROUTER_DESC = "OpenTela load-balances across the replica peers on the mesh"
+
+_AUTHORIZATION_HELP = (
+    "Who may list and use the model on the Serving API. "
+    f"'{PUBLIC}' (default): everyone. "
+    f"'{PRIVATE}': only you — SML resolves this to your own email via the Serving API's "
+    "/v1/whoami before submitting, so it needs your Swiss AI Research API key. "
+    "Or a comma-separated email list, e.g. 'user1@epfl.ch,user2@ethz.ch' "
+    "(the list is literal: it does NOT implicitly include you). "
+    f"Env: SML_AUTHORIZATION."
+)
+
+
+def _add_authorization_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--authorization",
+        dest="authorization",
+        default=os.environ.get("SML_AUTHORIZATION", PUBLIC),
+        metavar="POLICY",
+        help=_AUTHORIZATION_HELP,
+    )
 
 
 def _make_firecrest_launcher_config(
@@ -161,6 +188,15 @@ def _make_launch_request_config(
                 validator=lambda v: bool(re.fullmatch(r"[0-9]{1,2}:[0-5][0-9]:[0-5][0-9]", v)),
                 default="03:00:00",
             ),
+            TextConfiguration(
+                name="authorization",
+                prompt=(
+                    f"Who may use the model: '{PUBLIC}' (anyone), '{PRIVATE}' (only you), or comma-separated emails."
+                ),
+                validator=is_valid_authorization,
+                default=PUBLIC,
+                env_var="SML_AUTHORIZATION",
+            ),
         ],
     )
 
@@ -260,6 +296,7 @@ def _add_advanced_launch_arguments(
         default=None,
         help="Name under which the model will be served. Auto-generated if omitted.",
     )
+    _add_authorization_argument(advanced_parser)
     advanced_parser.add_argument(
         "--router",
         dest="router",
@@ -566,6 +603,9 @@ async def _get_launch_request(launcher: Launcher, args: argparse.Namespace | Non
         time=launch_req_config.get_non_none_value("time"),
         served_model_name=namespace_served_model_name(model, launcher.username),
         router=cast(RouterMode, launch_req_config.get_non_none_value("router")),
+        # Still raw here ("public" / "private" / emails): resolving `private`
+        # needs the API key, which only the launch commands hold.
+        authorization=launch_req_config.get_non_none_value("authorization"),
     )
 
 
@@ -747,6 +787,14 @@ async def _run_preconfigured(args: argparse.Namespace) -> None:
     launcher = await _create_launcher(config, args)
     swissai_research_api_key = config.get_non_none_value("swissai_research_api_key")
     launch_request = await _get_launch_request(launcher, args)
+    authorization = await resolve_authorization(launch_request.authorization, swissai_research_api_key)
+    launch_request = launch_request.model_copy(update={"authorization": authorization})
+    await warn_or_refuse_conflict(
+        swissai_research_api_key,
+        cast(str, launch_request.served_model_name),
+        authorization,
+    )
+    print(f"Authorization: {describe(authorization)}")
     launch_coro = launcher.launch_model(launch_request)
     if args.tui:
         await _run_monitor(
@@ -771,6 +819,7 @@ def build_launch_args_from_advanced(
     account: str,
     partition: str,
     telemetry_endpoint: str | None = None,
+    authorization: str = PUBLIC,
 ) -> LaunchArgs:
     """Build a LaunchArgs from a parsed `sml advanced` namespace.
 
@@ -835,6 +884,7 @@ def build_launch_args_from_advanced(
         disable_dcgm_exporter=args.disable_dcgm_exporter,
         disable_metrics=args.disable_metrics,
         telemetry_endpoint=telemetry_endpoint,
+        authorization=authorization,
     )
 
 
@@ -847,13 +897,24 @@ async def _run_advanced(args: argparse.Namespace) -> None:
     launcher = await _create_launcher(config, args, non_interactive=True)
     swissai_research_api_key = config.get_non_none_value("swissai_research_api_key")
 
+    authorization = await resolve_authorization(requested_from_args(args), swissai_research_api_key)
     launch_args = build_launch_args_from_advanced(
         args,
         username=launcher.username,
         account=launcher.account,
         partition=launcher.partition,
         telemetry_endpoint=TELEMETRY_ENDPOINT,
+        authorization=authorization,
     )
+    if not args.output_script:
+        # --output-script only renders scripts; nothing joins the mesh, so
+        # there is no collision to check for (and no reason to need network).
+        await warn_or_refuse_conflict(
+            swissai_research_api_key,
+            launch_args.served_model_name,
+            authorization,
+        )
+        print(f"Authorization: {describe(authorization)}")
 
     # Decide single vs. consecutive chain. --time is the total uptime; a job is
     # capped at --max-job-time, so anything longer needs --consecutive and is

--- a/src/swiss_ai_model_launch/launchers/authorization.py
+++ b/src/swiss_ai_model_launch/launchers/authorization.py
@@ -1,0 +1,103 @@
+"""Launch-time access control for a served model.
+
+Every model SML puts on the mesh carries an OpenTela peer label
+``authorization`` that tells the Serving API gateway who may list and use it:
+
+- ``public`` (the default) — anyone, including anonymous ``/v1/models`` callers.
+- a comma-separated email list — only those users.
+
+``private`` is a THIRD spelling that exists only in the CLI. The gateway has no
+idea who launched a job, so "only me" cannot be expressed as a label; SML
+resolves ``private`` to the launcher's own email (via the Serving API's
+``/v1/whoami``) before the job is submitted, and the literal string never
+reaches the mesh. :class:`~swiss_ai_model_launch.launchers.launch_args.LaunchArgs`
+rejects it as a guardrail against a code path that forgets to resolve it.
+
+Labels are self-asserted — anyone who can join the mesh can claim any label —
+so this is access control at the gateway, not authentication on the mesh. See
+serving-api ADR-0001.
+"""
+
+import re
+
+PUBLIC = "public"
+PRIVATE = "private"
+
+# Deliberately loose: the gateway matches the label against an API key's
+# owner_email verbatim, so our job is to catch typos and shell-quoting
+# accidents ("--authorization user1@epfl.ch user2@ethz.ch" arriving as one
+# arg), not to adjudicate what a valid address is.
+_EMAIL_RE = re.compile(r"^[^@\s,]+@[^@\s,]+\.[^@\s,]+$")
+
+
+def normalize_authorization(value: str) -> str:
+    """Canonicalize a ``--authorization`` value, or raise ValueError.
+
+    ``public``/``private`` are returned lowercased and unchanged otherwise.
+    An email list is stripped, lowercased, de-duplicated (order preserved)
+    and rejoined with commas — matching what the gateway normalizes to, so
+    two launches that mean the same policy emit the same label string and
+    do not read as a served-name conflict.
+    """
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("--authorization must not be empty; use 'public', 'private', or an email list.")
+
+    lowered = text.lower()
+    if lowered in (PUBLIC, PRIVATE):
+        return lowered
+
+    emails: list[str] = []
+    for part in text.split(","):
+        email = part.strip().lower()
+        if not email:
+            continue
+        if email in (PUBLIC, PRIVATE):
+            raise ValueError(
+                f"--authorization {value!r} mixes {email!r} with an email list. "
+                f"Use either '{PUBLIC}', '{PRIVATE}', or a comma-separated list of emails."
+            )
+        if not _EMAIL_RE.match(email):
+            raise ValueError(
+                f"--authorization {value!r} is not a valid access policy: {email!r} is not an email address. "
+                f"Use '{PUBLIC}', '{PRIVATE}', or a comma-separated list like 'a@epfl.ch,b@ethz.ch'."
+            )
+        if email not in emails:
+            emails.append(email)
+
+    if not emails:
+        raise ValueError(f"--authorization {value!r} lists no email addresses.")
+    return ",".join(emails)
+
+
+def is_private(value: str) -> bool:
+    return (value or "").strip().lower() == PRIVATE
+
+
+def is_public(value: str) -> bool:
+    """Public is also how the gateway reads a missing or empty label, so
+    pre-feature launches keep working."""
+    text = (value or "").strip().lower()
+    return not text or text == PUBLIC
+
+
+def policy_of(value: str) -> frozenset[str] | None:
+    """A label value as a comparable policy: None for public, else the email
+    set. Two label strings that differ only in order, case or spacing give
+    the same policy — which is what a conflict check must compare, so that
+    re-launching with a reordered list is not treated as a conflict.
+
+    Mirrors ``normalize_policy`` in the gateway's authorization service.
+    """
+    text = (value or "").strip()
+    if not text or text.lower() == PUBLIC:
+        return None
+    return frozenset(part.strip().lower() for part in text.split(",") if part.strip())
+
+
+def describe(value: str) -> str:
+    """One-line human summary for launch output."""
+    if is_public(value):
+        return "public (anyone can list and use this model)"
+    emails = sorted(policy_of(value) or ())
+    return f"restricted to {len(emails)} user(s): {', '.join(emails)}"

--- a/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
@@ -136,6 +136,7 @@ class FirecRESTLauncher(Launcher):
             pre_launch_cmds=launch_request.pre_launch_cmds or "",
             telemetry_endpoint=self.telemetry_endpoint,
             router=launch_request.router,
+            authorization=launch_request.authorization,
         )
 
     def _get_local_env_file_path(self, launch_request: LaunchRequest) -> str:

--- a/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
@@ -142,6 +142,7 @@ class FirecRESTLauncher(Launcher):
             pre_launch_cmds=launch_request.pre_launch_cmds or "",
             telemetry_endpoint=self.telemetry_endpoint,
             router=launch_request.router,
+            authorization=launch_request.authorization,
         )
 
     def _get_local_env_file_path(self, launch_request: LaunchRequest) -> str:

--- a/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
@@ -12,7 +12,7 @@ from swiss_ai_model_launch.launchers.launch_args import LaunchArgs
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.launcher import Launcher, TerminalCommand
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
-from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
+from swiss_ai_model_launch.launchers.served_name import derive_served_model_name, namespace_served_model_name
 from swiss_ai_model_launch.launchers.topology import Topology
 from swiss_ai_model_launch.launchers.utils import (
     MODEL_REGISTRY,
@@ -121,7 +121,13 @@ class FirecRESTLauncher(Launcher):
     ) -> LaunchArgs:
         model = launch_request.model
         job_name = launch_request.job_name or f"{model.replace('/', '_')}_{self.username}_{create_salt(8)}"
-        served_model_name = namespace_served_model_name(launch_request.served_model_name or model, self.username)
+        # An explicit name is honoured as given; only a name we invent carries
+        # the framework suffix that keeps sglang and vllm launches apart.
+        served_model_name = (
+            namespace_served_model_name(launch_request.served_model_name, self.username)
+            if launch_request.served_model_name
+            else derive_served_model_name(model, launch_request.framework, self.username)
+        )
         return LaunchArgs(
             job_name=job_name,
             account=self.account,

--- a/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
@@ -12,7 +12,7 @@ from swiss_ai_model_launch.launchers.launch_args import LaunchArgs
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.launcher import Launcher, TerminalCommand
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
-from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
+from swiss_ai_model_launch.launchers.served_name import derive_served_model_name, namespace_served_model_name
 from swiss_ai_model_launch.launchers.topology import Topology
 from swiss_ai_model_launch.launchers.utils import (
     call_with_firecrest_retry,
@@ -115,7 +115,13 @@ class FirecRESTLauncher(Launcher):
     ) -> LaunchArgs:
         model = launch_request.model
         job_name = f"{model.replace('/', '_')}_{self.username}_{create_salt(8)}"
-        served_model_name = namespace_served_model_name(launch_request.served_model_name or model, self.username)
+        # An explicit name is honoured as given; only a name we invent carries
+        # the framework suffix that keeps sglang and vllm launches apart.
+        served_model_name = (
+            namespace_served_model_name(launch_request.served_model_name, self.username)
+            if launch_request.served_model_name
+            else derive_served_model_name(model, launch_request.framework, self.username)
+        )
         return LaunchArgs(
             job_name=job_name,
             account=self.account,

--- a/src/swiss_ai_model_launch/launchers/framework.py
+++ b/src/swiss_ai_model_launch/launchers/framework.py
@@ -92,6 +92,10 @@ def _opentela_labels(launch_args: LaunchArgs) -> str:
     user_input = [
         f"framework={launch_args.framework}",
         f"served_model_name={launch_args.served_model_name}",
+        # The gateway's access-control input: "public" or an email list. It is
+        # shlex-quoted like the other user-supplied labels because an email
+        # list is one comma-separated argument.
+        f"authorization={launch_args.authorization}",
         f"framework_args={framework_args_normalised}",
     ]
     quoted = " \\\n".join(f"    --label {shlex.quote(kv)}" for kv in user_input)

--- a/src/swiss_ai_model_launch/launchers/framework.py
+++ b/src/swiss_ai_model_launch/launchers/framework.py
@@ -83,6 +83,23 @@ def _compose_framework_args(launch_args: LaunchArgs) -> str:
     return f"--port {FRAMEWORK_PORT} {launch_args.framework_args}".strip()
 
 
+def _sml_version() -> str:
+    """The SML version rendering this launch.
+
+    Resolved here, on the machine that submits the job, not on the compute node
+    — SML is not installed there, and what we want to record is the version
+    that produced the script.
+
+    Falls back to "unknown" when the package metadata is missing (running from
+    a source checkout that was never installed). A launch is not worth failing
+    over a provenance label.
+    """
+    try:
+        return importlib.metadata.version("swiss-ai-model-launch")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
 def _opentela_labels(launch_args: LaunchArgs) -> str:
     # Users often write framework_args with bash line-continuations + indented
     # follow-on lines, which collapse to runs of whitespace inside the quoted
@@ -100,11 +117,16 @@ def _opentela_labels(launch_args: LaunchArgs) -> str:
     ]
     quoted = " \\\n".join(f"    --label {shlex.quote(kv)}" for kv in user_input)
     seconds = time_str_to_seconds(launch_args.time)
+    # Baked in as a literal rather than resolved on the node: this records which
+    # SML built the script, which is what you want when a launch misbehaves and
+    # you need to know whether it predates a fix.
+    sml_version = shlex.quote(f"sml_version={_sml_version()}")
     return (
         "    --label launched_by=$USER \\\n"
         "    --label slurm_job_id=$SLURM_JOB_ID \\\n"
         "    --label slurm_partition=${SLURM_JOB_PARTITION:-unknown} \\\n"
         "    --label worker_group_id=$SLURM_JOB_ID \\\n"
+        f"    --label {sml_version} \\\n"
         f"{quoted} \\\n"
         "    --label started_at=$(date -u +%FT%TZ) \\\n"
         f'    --label expires_at=$(date -u -d "+{seconds} seconds" +%FT%TZ) \\\n'
@@ -379,7 +401,7 @@ def _render_telemetry(launch_args: LaunchArgs) -> str:
     # metrics-only). Otherwise each head advertises `llm` on the framework port.
     opentela_service_port = SGLANG_ROUTER_PORT if _fronted_by_router(launch_args) else FRAMEWORK_PORT
     fa = _compose_framework_args(launch_args)
-    sml_version = importlib.metadata.version("swiss-ai-model-launch")
+    sml_version = _sml_version()
     # The four telemetry keys below keep their original pre-rebrand spelling to match
     # the external ingestion schema and must not be renamed.
     payload = (

--- a/src/swiss_ai_model_launch/launchers/launch_args.py
+++ b/src/swiss_ai_model_launch/launchers/launch_args.py
@@ -5,6 +5,12 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from swiss_ai_model_launch.launchers.authorization import (
+    PRIVATE,
+    PUBLIC,
+    is_private,
+    normalize_authorization,
+)
 from swiss_ai_model_launch.launchers.topology import Topology
 
 # Routing strategy across replicas. OpenTela (default): OpenTela load-balances across
@@ -88,6 +94,11 @@ class LaunchArgs(BaseModel):
     previous_job_id: int | None = None
     environment: str
 
+    # Who may list and use the model once it is on the mesh: "public" or a
+    # comma-separated email list. "private" is resolved to the launcher's own
+    # email by the CLI before we get here — see the validator below.
+    authorization: str = PUBLIC
+
     framework: str
     framework_args: str = ""
     pre_launch_cmds: str = ""
@@ -107,6 +118,20 @@ class LaunchArgs(BaseModel):
     def _validate(self) -> "LaunchArgs":
         if not self.disable_metrics and not self.metrics_remote_write_url:
             raise ValueError("Metrics require a remote write URL when metrics are enabled.")
+        if is_private(self.authorization):
+            # A guardrail, not a user-facing error: every CLI path resolves
+            # `private` to the launcher's email via /v1/whoami before building
+            # LaunchArgs. Reaching here means a code path skipped that, and
+            # emitting the literal label would silently publish the model to
+            # everyone — the gateway has no "private" in its grammar.
+            raise ValueError(
+                f"authorization={PRIVATE!r} must be resolved to the launcher's email before launch; "
+                f"the mesh label only understands {PUBLIC!r} or an email list."
+            )
+        # Normalizing here (rather than only in the CLI) keeps the label
+        # canonical for launches built programmatically — tests, the MCP
+        # server, and the example scripts all construct LaunchArgs directly.
+        self.authorization = normalize_authorization(self.authorization)
         if _PORT_FLAG_RE.search(self.framework_args):
             warnings.warn(
                 f"`--port` in framework_args is redundant; the framework port is hardcoded "

--- a/src/swiss_ai_model_launch/launchers/launch_request.py
+++ b/src/swiss_ai_model_launch/launchers/launch_request.py
@@ -2,6 +2,7 @@ from typing import Literal, Self
 
 from pydantic import BaseModel
 
+from swiss_ai_model_launch.launchers.authorization import PUBLIC
 from swiss_ai_model_launch.launchers.launch_args import ROUTER_OPENTELA, RouterMode
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
 
@@ -24,6 +25,10 @@ class LaunchRequest(BaseModel):
     # job by this name and returns it instead of submitting a second one.
     # Unset, a unique random name is generated.
     job_name: str | None = None
+    # Access policy for the served model: "public" or a comma-separated email
+    # list. Never "private" — the CLI resolves that to the launcher's email
+    # before a request is built.
+    authorization: str = PUBLIC
 
     @classmethod
     def from_catalog_entry(
@@ -34,6 +39,7 @@ class LaunchRequest(BaseModel):
         time: str,
         served_model_name: str | None = None,
         router: RouterMode = ROUTER_OPENTELA,
+        authorization: str = PUBLIC,
     ) -> Self:
         return cls(
             model=entry.model,
@@ -47,4 +53,5 @@ class LaunchRequest(BaseModel):
             served_model_name=served_model_name,
             router=router,
             model_path=entry.model_path,
+            authorization=authorization,
         )

--- a/src/swiss_ai_model_launch/launchers/launch_request.py
+++ b/src/swiss_ai_model_launch/launchers/launch_request.py
@@ -2,6 +2,7 @@ from typing import Literal, Self
 
 from pydantic import BaseModel
 
+from swiss_ai_model_launch.launchers.authorization import PUBLIC
 from swiss_ai_model_launch.launchers.launch_args import ROUTER_OPENTELA, RouterMode
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
 
@@ -18,6 +19,10 @@ class LaunchRequest(BaseModel):
     pre_launch_cmds: str | None = None
     router: RouterMode = ROUTER_OPENTELA
     model_path: str | None = None
+    # Access policy for the served model: "public" or a comma-separated email
+    # list. Never "private" — the CLI resolves that to the launcher's email
+    # before a request is built.
+    authorization: str = PUBLIC
 
     @classmethod
     def from_catalog_entry(
@@ -28,6 +33,7 @@ class LaunchRequest(BaseModel):
         time: str,
         served_model_name: str | None = None,
         router: RouterMode = ROUTER_OPENTELA,
+        authorization: str = PUBLIC,
     ) -> Self:
         return cls(
             model=entry.model,
@@ -41,4 +47,5 @@ class LaunchRequest(BaseModel):
             served_model_name=served_model_name,
             router=router,
             model_path=entry.model_path,
+            authorization=authorization,
         )

--- a/src/swiss_ai_model_launch/launchers/served_name.py
+++ b/src/swiss_ai_model_launch/launchers/served_name.py
@@ -2,9 +2,15 @@
 
 Every model SML puts on the mesh is served under ``<username>/<vendor>/<model>``,
 where ``username`` is the cluster account that submitted the SLURM job — the
-same value the job advertises as the OpenTela ``launched_by`` label. The
-gateway cross-checks the two (see the serving-api authorization service), so
-the namespace must be the launcher's own username and nothing else.
+same value the job advertises as the OpenTela ``launched_by`` label. Callers are
+expected to write the namespace out (the examples use ``$USER/...``); we still
+prepend it when it is missing so pre-namespacing scripts keep working, and we
+refuse a name under anyone else's username.
+
+That refusal is ours, not the gateway's: the gateway only requires three
+non-empty segments before it will list an id, and does not check the namespace
+against ``launched_by``. So this stops users from accidentally publishing under
+each other's names; it is not an ownership guarantee.
 
 Namespacing replaces the random salt that used to disambiguate served names:
 two users launching the same model no longer collide, and a name is now

--- a/src/swiss_ai_model_launch/launchers/served_name.py
+++ b/src/swiss_ai_model_launch/launchers/served_name.py
@@ -15,8 +15,15 @@ each other's names; it is not an ownership guarantee.
 Namespacing replaces the random salt that used to disambiguate served names:
 two users launching the same model no longer collide, and a name is now
 predictable from who launched what. Two launches by the SAME user of the same
-model do share a name — deliberately, since they carry identical labels and
-OpenTela simply load-balances across them as extra replicas.
+model *on the same framework* do share a name — deliberately, since they carry
+identical labels and OpenTela simply load-balances across them as extra
+replicas.
+
+The framework is part of a derived name (``derive_served_model_name``) because
+it is not part of the model id but does change what is being served: without
+it, one user running the same model on sglang and on vllm would put two
+different engines on the mesh under a single id, and OpenTela would balance
+across them. The salt used to hide that; nothing else does.
 """
 
 # A name with fewer than this many segments predates namespacing (bare
@@ -67,3 +74,17 @@ def namespace_served_model_name(served_model_name: str, username: str) -> str:
             f"{username}/{name.split('/', 1)[1]} or drop the namespace and let SML add it."
         )
     return name
+
+
+def derive_served_model_name(model: str, framework: str, username: str) -> str:
+    """The served name for a launch that did not choose one.
+
+    ``<username>/<model id>-<framework>``. The framework suffix keeps a user's
+    sglang and vllm deployments of one model apart; see the module docstring
+    for why that matters. Callers that DO pass an explicit name get it
+    verbatim (namespaced) — this is only the default.
+    """
+    framework = framework.strip()
+    if not framework:
+        raise ValueError("Cannot derive a served model name without a framework.")
+    return namespace_served_model_name(f"{model.strip()}-{framework}", username)

--- a/src/swiss_ai_model_launch/launchers/slurm_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/slurm_launcher.py
@@ -10,7 +10,7 @@ from swiss_ai_model_launch.launchers.launch_args import LaunchArgs
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.launcher import Launcher, TerminalCommand
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
-from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
+from swiss_ai_model_launch.launchers.served_name import derive_served_model_name, namespace_served_model_name
 from swiss_ai_model_launch.launchers.topology import Topology
 from swiss_ai_model_launch.launchers.utils import (
     MODEL_REGISTRY,
@@ -73,7 +73,13 @@ class SlurmLauncher(Launcher):
     def _get_launch_args_from_request(self, launch_request: LaunchRequest) -> LaunchArgs:
         model = launch_request.model
         job_name = launch_request.job_name or f"{model.replace('/', '_')}_{self.username}_{create_salt(8)}"
-        served_model_name = namespace_served_model_name(launch_request.served_model_name or model, self.username)
+        # An explicit name is honoured as given; only a name we invent carries
+        # the framework suffix that keeps sglang and vllm launches apart.
+        served_model_name = (
+            namespace_served_model_name(launch_request.served_model_name, self.username)
+            if launch_request.served_model_name
+            else derive_served_model_name(model, launch_request.framework, self.username)
+        )
         return LaunchArgs(
             job_name=job_name,
             account=self.account,

--- a/src/swiss_ai_model_launch/launchers/slurm_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/slurm_launcher.py
@@ -94,6 +94,7 @@ class SlurmLauncher(Launcher):
             pre_launch_cmds=launch_request.pre_launch_cmds or "",
             telemetry_endpoint=self.telemetry_endpoint,
             router=launch_request.router,
+            authorization=launch_request.authorization,
         )
 
     def _get_local_env_file_path(self, launch_request: LaunchRequest) -> str:

--- a/src/swiss_ai_model_launch/launchers/slurm_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/slurm_launcher.py
@@ -95,6 +95,7 @@ class SlurmLauncher(Launcher):
             pre_launch_cmds=launch_request.pre_launch_cmds or "",
             telemetry_endpoint=self.telemetry_endpoint,
             router=launch_request.router,
+            authorization=launch_request.authorization,
         )
 
     def _get_local_env_file_path(self, launch_request: LaunchRequest) -> str:

--- a/src/swiss_ai_model_launch/launchers/slurm_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/slurm_launcher.py
@@ -10,7 +10,7 @@ from swiss_ai_model_launch.launchers.launch_args import LaunchArgs
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.launcher import Launcher, TerminalCommand
 from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntry
-from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
+from swiss_ai_model_launch.launchers.served_name import derive_served_model_name, namespace_served_model_name
 from swiss_ai_model_launch.launchers.topology import Topology
 from swiss_ai_model_launch.launchers.utils import (
     create_salt,
@@ -74,7 +74,13 @@ class SlurmLauncher(Launcher):
     def _get_launch_args_from_request(self, launch_request: LaunchRequest) -> LaunchArgs:
         model = launch_request.model
         job_name = f"{model.replace('/', '_')}_{self.username}_{create_salt(8)}"
-        served_model_name = namespace_served_model_name(launch_request.served_model_name or model, self.username)
+        # An explicit name is honoured as given; only a name we invent carries
+        # the framework suffix that keeps sglang and vllm launches apart.
+        served_model_name = (
+            namespace_served_model_name(launch_request.served_model_name, self.username)
+            if launch_request.served_model_name
+            else derive_served_model_name(model, launch_request.framework, self.username)
+        )
         return LaunchArgs(
             job_name=job_name,
             account=self.account,

--- a/src/swiss_ai_model_launch/mcp/server.py
+++ b/src/swiss_ai_model_launch/mcp/server.py
@@ -14,12 +14,14 @@ from fastmcp import Context
 from swiss_ai_model_launch.cli.configuration import InitConfig, optional_value
 from swiss_ai_model_launch.cli.healthcheck import ModelHealth, check_model_health
 from swiss_ai_model_launch.launchers import FirecRESTLauncher, Launcher, SlurmLauncher
+from swiss_ai_model_launch.launchers.authorization import PUBLIC, is_private, normalize_authorization
 from swiss_ai_model_launch.launchers.firecrest_auth import build_client
 from swiss_ai_model_launch.launchers.job_status import JobStatus
 from swiss_ai_model_launch.launchers.launch_args import TELEMETRY_ENDPOINT
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
 from swiss_ai_model_launch.launchers.utils import call_with_firecrest_retry
+from swiss_ai_model_launch.serving_api import ServingApiError, whoami
 
 _POLL_INTERVAL_SECONDS = 10
 _TERMINAL_STATUSES = {JobStatus.TIMEOUT, JobStatus.UNKNOWN}
@@ -260,6 +262,14 @@ async def launch_preconfigured_model(
         "the replica peers on the mesh. 'sglang': an in-job SGLang router fronts the replicas "
         "and becomes the served endpoint (needs replicas > 1).",
     ] = "opentela",
+    authorization: Annotated[
+        str,
+        "Who may list and use the model on the Serving API. 'public' (default): everyone. "
+        "'private': only the launching user — resolved to their email via the Serving API's "
+        "/v1/whoami, which needs SWISSAI_RESEARCH_API_KEY to be configured. Or a "
+        "comma-separated email list, e.g. 'user1@epfl.ch,user2@ethz.ch' (literal: it does "
+        "not implicitly include the launcher).",
+    ] = PUBLIC,
 ) -> str:
     """Launch a preconfigured model on an HPC cluster and wait for it to become healthy.
 
@@ -293,17 +303,33 @@ async def launch_preconfigured_model(
             f"Model '{model}' with framework '{framework}' was not found in the catalogue. "
             "Use `list_preconfigured_models` to see available models."
         )
+    config = InitConfig.load()
+    swissai_research_api_key = config.get_value("swissai_research_api_key")
+    try:
+        resolved_authorization = normalize_authorization(authorization)
+        if is_private(resolved_authorization):
+            # The mesh label has no "private": it must become the launcher's
+            # own email before the job is submitted.
+            if not swissai_research_api_key:
+                return (
+                    "authorization='private' needs SWISSAI_RESEARCH_API_KEY to resolve your "
+                    "email via the Serving API. Configure it with `sml init`, or pass an "
+                    "explicit email list."
+                )
+            resolved_authorization = normalize_authorization(await whoami(swissai_research_api_key))
+    except (ValueError, ServingApiError) as e:
+        return f"Could not apply authorization={authorization!r}: {e}"
+
     request = LaunchRequest.from_catalog_entry(
         entry,
         replicas=replicas,
         time=time,
         served_model_name=namespace_served_model_name(model, launcher.username),
         router=router,
+        authorization=resolved_authorization,
     )
     job_id, served = await launcher.launch_model(request)
     await ctx.info(f"Job submitted — job_id={job_id}, served_model_name={served}")
-    config = InitConfig.load()
-    swissai_research_api_key = config.get_value("swissai_research_api_key")
     stdout_lines_sent = 0
     stderr_lines_sent = 0
     ever_healthy = False

--- a/src/swiss_ai_model_launch/mcp/server.py
+++ b/src/swiss_ai_model_launch/mcp/server.py
@@ -14,11 +14,13 @@ from fastmcp import Context
 from swiss_ai_model_launch.cli.configuration import InitConfig
 from swiss_ai_model_launch.cli.healthcheck import ModelHealth, check_model_health
 from swiss_ai_model_launch.launchers import FirecRESTLauncher, Launcher, SlurmLauncher
+from swiss_ai_model_launch.launchers.authorization import PUBLIC, is_private, normalize_authorization
 from swiss_ai_model_launch.launchers.job_status import JobStatus
 from swiss_ai_model_launch.launchers.launch_args import TELEMETRY_ENDPOINT
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
 from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
 from swiss_ai_model_launch.launchers.utils import call_with_firecrest_retry
+from swiss_ai_model_launch.serving_api import ServingApiError, whoami
 
 _POLL_INTERVAL_SECONDS = 10
 _TERMINAL_STATUSES = {JobStatus.TIMEOUT, JobStatus.UNKNOWN}
@@ -259,6 +261,14 @@ async def launch_preconfigured_model(
         "the replica peers on the mesh. 'sglang': an in-job SGLang router fronts the replicas "
         "and becomes the served endpoint (needs replicas > 1).",
     ] = "opentela",
+    authorization: Annotated[
+        str,
+        "Who may list and use the model on the Serving API. 'public' (default): everyone. "
+        "'private': only the launching user — resolved to their email via the Serving API's "
+        "/v1/whoami, which needs SWISSAI_RESEARCH_API_KEY to be configured. Or a "
+        "comma-separated email list, e.g. 'user1@epfl.ch,user2@ethz.ch' (literal: it does "
+        "not implicitly include the launcher).",
+    ] = PUBLIC,
 ) -> str:
     """Launch a preconfigured model on an HPC cluster and wait for it to become healthy.
 
@@ -292,17 +302,33 @@ async def launch_preconfigured_model(
             f"Model '{model}' with framework '{framework}' was not found in the catalogue. "
             "Use `list_preconfigured_models` to see available models."
         )
+    config = InitConfig.load()
+    swissai_research_api_key = config.get_value("swissai_research_api_key")
+    try:
+        resolved_authorization = normalize_authorization(authorization)
+        if is_private(resolved_authorization):
+            # The mesh label has no "private": it must become the launcher's
+            # own email before the job is submitted.
+            if not swissai_research_api_key:
+                return (
+                    "authorization='private' needs SWISSAI_RESEARCH_API_KEY to resolve your "
+                    "email via the Serving API. Configure it with `sml init`, or pass an "
+                    "explicit email list."
+                )
+            resolved_authorization = normalize_authorization(await whoami(swissai_research_api_key))
+    except (ValueError, ServingApiError) as e:
+        return f"Could not apply authorization={authorization!r}: {e}"
+
     request = LaunchRequest.from_catalog_entry(
         entry,
         replicas=replicas,
         time=time,
         served_model_name=namespace_served_model_name(model, launcher.username),
         router=router,
+        authorization=resolved_authorization,
     )
     job_id, served = await launcher.launch_model(request)
     await ctx.info(f"Job submitted — job_id={job_id}, served_model_name={served}")
-    config = InitConfig.load()
-    swissai_research_api_key = config.get_value("swissai_research_api_key")
     stdout_lines_sent = 0
     stderr_lines_sent = 0
     ever_healthy = False

--- a/src/swiss_ai_model_launch/mcp/server.py
+++ b/src/swiss_ai_model_launch/mcp/server.py
@@ -18,7 +18,7 @@ from swiss_ai_model_launch.launchers.authorization import PUBLIC, is_private, no
 from swiss_ai_model_launch.launchers.job_status import JobStatus
 from swiss_ai_model_launch.launchers.launch_args import TELEMETRY_ENDPOINT
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
-from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
+from swiss_ai_model_launch.launchers.served_name import derive_served_model_name
 from swiss_ai_model_launch.launchers.utils import call_with_firecrest_retry
 from swiss_ai_model_launch.serving_api import ServingApiError, whoami
 
@@ -52,7 +52,8 @@ mcp = fastmcp.FastMCP(
         "   periodic [status] lines as MCP notifications while you wait. It returns only when\n"
         "   the model is healthy or the job reaches a terminal state. The return value includes\n"
         "   the served_model_name — your launch's identifier, namespaced under the cluster\n"
-        "   username that submitted the job (e.g. 'alice/swiss-ai/Apertus-70B') — that you\n"
+        "   username that submitted the job and suffixed with the framework\n"
+        "   (e.g. 'alice/swiss-ai/Apertus-70B-sglang') — that you\n"
         "   pass as the 'model' field when sending inference requests to the cluster API\n"
         "   endpoint.\n\n"
         "5. **Operate** — use `get_job_status` to poll a running job (returns PENDING, RUNNING,\n"
@@ -323,7 +324,7 @@ async def launch_preconfigured_model(
         entry,
         replicas=replicas,
         time=time,
-        served_model_name=namespace_served_model_name(model, launcher.username),
+        served_model_name=derive_served_model_name(model, framework, launcher.username),
         router=router,
         authorization=resolved_authorization,
     )

--- a/src/swiss_ai_model_launch/mcp/server.py
+++ b/src/swiss_ai_model_launch/mcp/server.py
@@ -19,7 +19,7 @@ from swiss_ai_model_launch.launchers.firecrest_auth import build_client
 from swiss_ai_model_launch.launchers.job_status import JobStatus
 from swiss_ai_model_launch.launchers.launch_args import TELEMETRY_ENDPOINT
 from swiss_ai_model_launch.launchers.launch_request import LaunchRequest
-from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
+from swiss_ai_model_launch.launchers.served_name import derive_served_model_name
 from swiss_ai_model_launch.launchers.utils import call_with_firecrest_retry
 from swiss_ai_model_launch.serving_api import ServingApiError, whoami
 
@@ -53,7 +53,8 @@ mcp = fastmcp.FastMCP(
         "   periodic [status] lines as MCP notifications while you wait. It returns only when\n"
         "   the model is healthy or the job reaches a terminal state. The return value includes\n"
         "   the served_model_name — your launch's identifier, namespaced under the cluster\n"
-        "   username that submitted the job (e.g. 'alice/swiss-ai/Apertus-70B') — that you\n"
+        "   username that submitted the job and suffixed with the framework\n"
+        "   (e.g. 'alice/swiss-ai/Apertus-70B-sglang') — that you\n"
         "   pass as the 'model' field when sending inference requests to the cluster API\n"
         "   endpoint.\n\n"
         "5. **Operate** — use `get_job_status` to poll a running job (returns PENDING, RUNNING,\n"
@@ -324,7 +325,7 @@ async def launch_preconfigured_model(
         entry,
         replicas=replicas,
         time=time,
-        served_model_name=namespace_served_model_name(model, launcher.username),
+        served_model_name=derive_served_model_name(model, framework, launcher.username),
         router=router,
         authorization=resolved_authorization,
     )

--- a/src/swiss_ai_model_launch/serving_api.py
+++ b/src/swiss_ai_model_launch/serving_api.py
@@ -1,0 +1,82 @@
+"""Thin client for the Serving API (the gateway in front of the mesh).
+
+SML talks to it for two launch-time reasons:
+
+- ``whoami`` resolves the user's Swiss AI Research API key to the email the
+  gateway knows them by, which is what ``--authorization private`` becomes.
+- ``served_model_authorizations`` reports the ``authorization`` labels already
+  on the mesh for a served name, so a launch that would collide with a
+  *different* policy under the same name can be refused before submission
+  rather than becoming an unroutable model (see the conflict rule in
+  serving-api ADR-0001).
+"""
+
+import httpx
+
+BASE_URL = "https://api.swissai.svc.cscs.ch"
+_TIMEOUT_SECONDS = 10
+
+
+class ServingApiError(RuntimeError):
+    """The Serving API could not answer — network failure, or a non-2xx."""
+
+
+async def whoami(api_key: str) -> str:
+    """The email the gateway associates with ``api_key``.
+
+    Raises ServingApiError on an invalid key (401) or an unreachable API, so
+    the caller can fail the launch loudly: silently falling back to public
+    would be the opposite of what `--authorization private` asked for.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{BASE_URL}/v1/whoami",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=_TIMEOUT_SECONDS,
+            )
+    except (httpx.TransportError, httpx.TimeoutException) as exc:
+        raise ServingApiError(f"Could not reach the Serving API at {BASE_URL}: {exc}") from exc
+
+    if response.status_code == 401:
+        raise ServingApiError(
+            "The Serving API rejected your Swiss AI Research API key. "
+            "Check it with `sml init` (get one at https://serving.swissai.svc.cscs.ch)."
+        )
+    if not response.is_success:
+        raise ServingApiError(f"GET /v1/whoami returned HTTP {response.status_code}.")
+
+    email = (response.json() or {}).get("email")
+    if not email:
+        raise ServingApiError("GET /v1/whoami returned no email address.")
+    return str(email)
+
+
+async def served_model_authorizations(api_key: str, served_model_name: str) -> list[str]:
+    """The ``authorization`` label of every peer currently serving that name.
+
+    Best effort by design: it only sees what the *caller* is allowed to see,
+    so a same-named model restricted to somebody else is invisible here. The
+    gateway is the authority — this exists to turn the common case (relaunching
+    your own model under a different policy while the old job is still up) into
+    an error at submission time instead of a model nobody can route to.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{BASE_URL}/v1/models_detailed",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=_TIMEOUT_SECONDS,
+            )
+    except (httpx.TransportError, httpx.TimeoutException) as exc:
+        raise ServingApiError(f"Could not reach the Serving API at {BASE_URL}: {exc}") from exc
+
+    if not response.is_success:
+        raise ServingApiError(f"GET /v1/models_detailed returned HTTP {response.status_code}.")
+
+    entries = (response.json() or {}).get("data") or []
+    return [
+        str((entry.get("labels") or {}).get("authorization", ""))
+        for entry in entries
+        if entry.get("id") == served_model_name
+    ]

--- a/tests/integration/test_cli_examples.py
+++ b/tests/integration/test_cli_examples.py
@@ -80,10 +80,17 @@ async def test_cli_example_launches_and_health(
     cancel_launcher: FirecRESTLauncher,
     env: dict[str, str],
 ) -> None:
+    # The examples name their model "$USER/<vendor>/<model>", which a real
+    # user's shell expands to their cluster account. On a CI runner $USER is
+    # the runner's account (or unset), and SML rejects a served name namespaced
+    # under anyone but the submitting user — so pin it to the account FirecREST
+    # says we are, which is exactly what the launch will be submitted as.
+    script_env = {**os.environ, "USER": cancel_launcher.username}
     proc = await asyncio.create_subprocess_exec(
         "bash",
         str(script),
         cwd=_REPO_ROOT,
+        env=script_env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     )
@@ -103,6 +110,14 @@ async def test_cli_example_launches_and_health(
     served_match = re.search(r"Served model name:\s*(\S+)", stdout)
     assert served_match, f"{script.name}: no 'Served model name: <name>' line in output\n---\n{stdout}"
     served_model_name = served_match.group(1)
+    # The gateway only advertises three-segment ids, and the namespace has to
+    # be the launching account — assert the example produced one.
+    assert served_model_name.startswith(f"{cancel_launcher.username}/"), (
+        f"{script.name}: served name {served_model_name!r} is not namespaced under {cancel_launcher.username!r}"
+    )
+    assert len(served_model_name.split("/")) == 3, (
+        f"{script.name}: served name {served_model_name!r} is not <user>/<vendor>/<model>"
+    )
 
     try:
         await wait_for_job_running(cancel_launcher, job_id, _LAUNCH_TIMEOUT_MIN)

--- a/tests/integration/test_cli_examples.py
+++ b/tests/integration/test_cli_examples.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import re
 from pathlib import Path
 
@@ -49,10 +50,17 @@ async def test_cli_example_launches_and_health(
     cancel_launcher: FirecRESTLauncher,
     env: dict[str, str],
 ) -> None:
+    # The examples name their model "$USER/<vendor>/<model>", which a real
+    # user's shell expands to their cluster account. On a CI runner $USER is
+    # the runner's account (or unset), and SML rejects a served name namespaced
+    # under anyone but the submitting user — so pin it to the account FirecREST
+    # says we are, which is exactly what the launch will be submitted as.
+    script_env = {**os.environ, "USER": cancel_launcher.username}
     proc = await asyncio.create_subprocess_exec(
         "bash",
         str(script),
         cwd=_REPO_ROOT,
+        env=script_env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     )
@@ -72,6 +80,14 @@ async def test_cli_example_launches_and_health(
     served_match = re.search(r"Served model name:\s*(\S+)", stdout)
     assert served_match, f"{script.name}: no 'Served model name: <name>' line in output\n---\n{stdout}"
     served_model_name = served_match.group(1)
+    # The gateway only advertises three-segment ids, and the namespace has to
+    # be the launching account — assert the example produced one.
+    assert served_model_name.startswith(f"{cancel_launcher.username}/"), (
+        f"{script.name}: served name {served_model_name!r} is not namespaced under {cancel_launcher.username!r}"
+    )
+    assert len(served_model_name.split("/")) == 3, (
+        f"{script.name}: served name {served_model_name!r} is not <user>/<vendor>/<model>"
+    )
 
     try:
         await wait_for_job_running(cancel_launcher, job_id, _LAUNCH_TIMEOUT_MIN)

--- a/tests/integration/test_firecrest_launcher.py
+++ b/tests/integration/test_firecrest_launcher.py
@@ -79,11 +79,17 @@ async def test_launch_apertus_and_health(
     swissai_research_api_key: str,
     launch_request: LaunchRequest,
 ) -> None:
-    # Name the model explicitly rather than relying on SML to prepend the
-    # namespace: this is the form users are told to write, so CI should launch
-    # it that way. The launcher resolves the account from FirecREST, which is
-    # the only namespace it will accept.
-    expected_name = f"{launcher.username}/{launch_request.model}"
+    # Name the model explicitly rather than relying on SML to derive one: this
+    # is the form users are told to write, and the launcher only accepts its
+    # own account as the namespace.
+    #
+    # The name has to be unique per parametrization or the suite collides with
+    # itself — these run in parallel and a served name is a mesh-wide id.
+    # Framework separates the lightweight pair (one model, sglang + vllm);
+    # replicas/router separate the std matrix, which launches the same
+    # model+framework in three topologies.
+    topology = f"{launch_request.replicas}r" + ("-router" if launch_request.router == "sglang" else "")
+    expected_name = f"{launcher.username}/{launch_request.model}-{launch_request.framework}-{topology}"
     launch_request = launch_request.model_copy(update={"served_model_name": expected_name})
 
     job_id, served_model_name = await launcher.launch_model(launch_request)

--- a/tests/integration/test_firecrest_launcher.py
+++ b/tests/integration/test_firecrest_launcher.py
@@ -79,10 +79,17 @@ async def test_launch_apertus_and_health(
     swissai_research_api_key: str,
     launch_request: LaunchRequest,
 ) -> None:
+    # Name the model explicitly rather than relying on SML to prepend the
+    # namespace: this is the form users are told to write, so CI should launch
+    # it that way. The launcher resolves the account from FirecREST, which is
+    # the only namespace it will accept.
+    expected_name = f"{launcher.username}/{launch_request.model}"
+    launch_request = launch_request.model_copy(update={"served_model_name": expected_name})
+
     job_id, served_model_name = await launcher.launch_model(launch_request)
 
     assert isinstance(job_id, int)
-    assert served_model_name
+    assert served_model_name == expected_name
 
     try:
         await wait_for_job_running(launcher, job_id, _LAUNCH_TIMEOUT)

--- a/tests/integration/test_firecrest_launcher.py
+++ b/tests/integration/test_firecrest_launcher.py
@@ -126,10 +126,17 @@ async def test_launch_apertus_and_health(
     swissai_research_api_key: str,
     launch_request: LaunchRequest,
 ) -> None:
+    # Name the model explicitly rather than relying on SML to prepend the
+    # namespace: this is the form users are told to write, so CI should launch
+    # it that way. The launcher resolves the account from FirecREST, which is
+    # the only namespace it will accept.
+    expected_name = f"{launcher.username}/{launch_request.model}"
+    launch_request = launch_request.model_copy(update={"served_model_name": expected_name})
+
     job_id, served_model_name = await launcher.launch_model(launch_request)
 
     assert isinstance(job_id, int)
-    assert served_model_name
+    assert served_model_name == expected_name
 
     try:
         await wait_for_job_running(launcher, job_id, _LAUNCH_TIMEOUT)

--- a/tests/integration/test_firecrest_launcher.py
+++ b/tests/integration/test_firecrest_launcher.py
@@ -126,11 +126,17 @@ async def test_launch_apertus_and_health(
     swissai_research_api_key: str,
     launch_request: LaunchRequest,
 ) -> None:
-    # Name the model explicitly rather than relying on SML to prepend the
-    # namespace: this is the form users are told to write, so CI should launch
-    # it that way. The launcher resolves the account from FirecREST, which is
-    # the only namespace it will accept.
-    expected_name = f"{launcher.username}/{launch_request.model}"
+    # Name the model explicitly rather than relying on SML to derive one: this
+    # is the form users are told to write, and the launcher only accepts its
+    # own account as the namespace.
+    #
+    # The name has to be unique per parametrization or the suite collides with
+    # itself — these run in parallel and a served name is a mesh-wide id.
+    # Framework separates the lightweight pair (one model, sglang + vllm);
+    # replicas/router separate the std matrix, which launches the same
+    # model+framework in three topologies.
+    topology = f"{launch_request.replicas}r" + ("-router" if launch_request.router == "sglang" else "")
+    expected_name = f"{launcher.username}/{launch_request.model}-{launch_request.framework}-{topology}"
     launch_request = launch_request.model_copy(update={"served_model_name": expected_name})
 
     job_id, served_model_name = await launcher.launch_model(launch_request)

--- a/tests/unit/test_authorization.py
+++ b/tests/unit/test_authorization.py
@@ -1,0 +1,343 @@
+"""The --authorization policy: its grammar, how `private` is resolved before
+launch, the label it puts on the mesh, and the served-name conflict guard."""
+
+import argparse
+import asyncio
+
+import pytest
+
+from swiss_ai_model_launch.cli import authorization as cli_authorization
+from swiss_ai_model_launch.cli.authorization import (
+    requested_from_args,
+    resolve_authorization,
+    warn_or_refuse_conflict,
+)
+from swiss_ai_model_launch.cli.main import _build_parser, build_launch_args_from_advanced
+from swiss_ai_model_launch.launchers.authorization import (
+    describe,
+    is_private,
+    is_public,
+    normalize_authorization,
+    policy_of,
+)
+from swiss_ai_model_launch.launchers.framework import _opentela_labels
+from swiss_ai_model_launch.launchers.launch_args import LaunchArgs
+from swiss_ai_model_launch.serving_api import ServingApiError
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── grammar ─────────────────────────────────────────────────────────────────
+
+
+def test_public_and_private_are_canonicalized():
+    assert normalize_authorization("public") == "public"
+    assert normalize_authorization("  PUBLIC ") == "public"
+    assert normalize_authorization("Private") == "private"
+
+
+def test_email_list_is_lowercased_stripped_and_deduped():
+    assert normalize_authorization(" User1@EPFL.ch , user2@ethz.ch ") == "user1@epfl.ch,user2@ethz.ch"
+    assert normalize_authorization("a@x.ch,a@X.ch") == "a@x.ch"
+
+
+def test_non_email_values_are_rejected():
+    for bad in ("", "   ", "alice", "alice@", "@epfl.ch", "a@epfl.ch b@ethz.ch", ","):
+        with pytest.raises(ValueError):
+            normalize_authorization(bad)
+
+
+def test_mixing_a_keyword_into_a_list_is_rejected():
+    """'public,a@epfl.ch' is ambiguous — the gateway would read it as an email
+    list containing a bogus address, silently restricting a model the user
+    thought was public."""
+    with pytest.raises(ValueError, match="mixes"):
+        normalize_authorization("public,a@epfl.ch")
+
+
+def test_policy_ignores_order_case_and_spacing():
+    """Conflict detection compares policies, not strings — the same rule the
+    gateway applies, so a reordered relaunch is not a conflict."""
+    assert policy_of("a@x.ch, B@Y.ch") == policy_of("b@y.ch,a@x.ch")
+    assert policy_of("public") is None
+    assert policy_of("") is None
+    assert policy_of("a@x.ch") != policy_of("a@x.ch,b@y.ch")
+
+
+def test_predicates_and_description():
+    assert is_public("") and is_public("Public")
+    assert is_private("PRIVATE")
+    assert not is_public("a@epfl.ch")
+    assert "public" in describe("public")
+    assert "a@epfl.ch" in describe("a@epfl.ch")
+
+
+# ── LaunchArgs guardrail + label emission ───────────────────────────────────
+
+
+def _launch_args(**overrides) -> LaunchArgs:
+    base = dict(
+        job_name="job",
+        served_model_name="alice/swiss-ai/Apertus-70B",
+        account="proj01",
+        partition="normal",
+        environment="/env.toml",
+        framework="sglang",
+        time="02:00:00",
+    )
+    base.update(overrides)
+    return LaunchArgs(**base)
+
+
+def test_launch_args_default_is_public():
+    assert _launch_args().authorization == "public"
+
+
+def test_launch_args_refuses_an_unresolved_private():
+    """The mesh grammar has no 'private'; emitting it literally would publish
+    the model to everyone. Any path that forgets to resolve must fail loudly."""
+    with pytest.raises(ValueError, match="must be resolved"):
+        _launch_args(authorization="private")
+
+
+def test_launch_args_normalizes_the_label():
+    assert _launch_args(authorization=" A@EPFL.ch , b@ethz.ch ").authorization == "a@epfl.ch,b@ethz.ch"
+
+
+def test_labels_carry_the_authorization_policy():
+    labels = _opentela_labels(_launch_args(authorization="a@epfl.ch,b@ethz.ch"))
+    # Commas and @ need no shell quoting, so the label lands as-is — one
+    # argument, which is what OpenTela's --label expects.
+    assert "--label authorization=a@epfl.ch,b@ethz.ch" in labels
+
+
+def test_public_launch_still_emits_the_label():
+    """An explicit 'public' label and a missing one mean the same thing to the
+    gateway, but emitting it keeps the policy visible in the DNT."""
+    assert "authorization=public" in _opentela_labels(_launch_args())
+
+
+# ── CLI plumbing ────────────────────────────────────────────────────────────
+
+
+def _advanced_args(*extra: str):
+    return _build_parser().parse_args(
+        [
+            "advanced",
+            "--partition",
+            "normal",
+            "--framework",
+            "sglang",
+            "--environment",
+            "/path/to/env.toml",
+            "--framework-args",
+            "--served-model-name swiss-ai/Apertus-70B",
+            *extra,
+        ]
+    )
+
+
+def test_advanced_defaults_to_public():
+    args = _advanced_args()
+    assert args.authorization == "public"
+    la = build_launch_args_from_advanced(
+        args,
+        username="alice",
+        account="proj01",
+        partition="normal",
+        authorization=_run(resolve_authorization(requested_from_args(args), "sk-rc-key")),
+    )
+    assert la.authorization == "public"
+
+
+def test_advanced_accepts_an_email_list():
+    args = _advanced_args("--authorization", "User1@EPFL.ch,user2@ethz.ch")
+    resolved = _run(resolve_authorization(requested_from_args(args), "sk-rc-key"))
+    assert resolved == "user1@epfl.ch,user2@ethz.ch"
+
+
+def test_private_is_resolved_to_the_launchers_email(monkeypatch):
+    """The gateway can't know who launched a job, so 'private' has to become
+    the launcher's own email before submission."""
+    seen = {}
+
+    async def fake_whoami(api_key):
+        seen["api_key"] = api_key
+        return "Alice@EPFL.ch"
+
+    monkeypatch.setattr(cli_authorization, "whoami", fake_whoami)
+    args = _advanced_args("--authorization", "private")
+
+    assert _run(resolve_authorization(requested_from_args(args), "sk-rc-key")) == "alice@epfl.ch"
+    assert seen["api_key"] == "sk-rc-key"
+
+
+def test_private_fails_the_launch_when_whoami_is_unavailable(monkeypatch):
+    """Falling back to public here would be the exact opposite of what the
+    user asked for, so the launch stops instead."""
+
+    async def broken_whoami(api_key):
+        raise ServingApiError("boom")
+
+    monkeypatch.setattr(cli_authorization, "whoami", broken_whoami)
+    args = _advanced_args("--authorization", "private")
+
+    with pytest.raises(SystemExit, match="boom"):
+        _run(resolve_authorization(requested_from_args(args), "sk-rc-key"))
+
+
+def test_an_invalid_policy_exits_with_a_message_not_a_traceback():
+    args = _advanced_args("--authorization", "not-an-email")
+    with pytest.raises(SystemExit, match="not an email address"):
+        _run(resolve_authorization(requested_from_args(args), "sk-rc-key"))
+
+
+def test_env_var_supplies_the_default(monkeypatch):
+    monkeypatch.setenv("SML_AUTHORIZATION", "a@epfl.ch")
+    # The advanced flag reads the environment when the parser is built.
+    args = _build_parser().parse_args(
+        [
+            "advanced",
+            "--partition",
+            "normal",
+            "--framework",
+            "sglang",
+            "--environment",
+            "/env.toml",
+            "--framework-args",
+            "--served-model-name m",
+        ]
+    )
+    assert args.authorization == "a@epfl.ch"
+
+
+def test_guided_flow_asks_for_the_policy():
+    """`sml preconfigured` collects it through the same interactive chain as
+    replicas/time — so it is a visible choice, not a silent default — while
+    still accepting --authorization / SML_AUTHORIZATION non-interactively."""
+    args = _build_parser().parse_args(["preconfigured", "--partition", "normal", "--authorization", "a@epfl.ch"])
+    assert args.authorization == "a@epfl.ch"
+
+
+# ── served-name conflict guard ──────────────────────────────────────────────
+
+
+def _patch_existing(monkeypatch, values, error=None):
+    async def fake(api_key, served_model_name):
+        if error is not None:
+            raise error
+        return values
+
+    monkeypatch.setattr(cli_authorization, "served_model_authorizations", fake)
+
+
+def test_conflicting_policy_on_the_same_name_is_refused(monkeypatch):
+    """OpenTela load-balances a name across every peer serving it, so a
+    second launch with a different policy makes the gateway refuse the name
+    for everyone — including the model that is already running."""
+    _patch_existing(monkeypatch, ["a@epfl.ch"])
+    with pytest.raises(SystemExit, match="different authorization policy"):
+        _run(warn_or_refuse_conflict("sk-rc-key", "alice/swiss-ai/Apertus-70B", "public"))
+
+
+def test_same_policy_written_differently_is_not_a_conflict(monkeypatch):
+    _patch_existing(monkeypatch, ["b@ethz.ch,a@epfl.ch"])
+    _run(warn_or_refuse_conflict("sk-rc-key", "alice/swiss-ai/Apertus-70B", "A@EPFL.ch,b@ethz.ch"))
+
+
+def test_an_unlabeled_running_peer_reads_as_public(monkeypatch):
+    _patch_existing(monkeypatch, [""])
+    _run(warn_or_refuse_conflict("sk-rc-key", "alice/swiss-ai/Apertus-70B", "public"))
+
+
+def test_no_running_peers_is_not_a_conflict(monkeypatch):
+    _patch_existing(monkeypatch, [])
+    _run(warn_or_refuse_conflict("sk-rc-key", "alice/swiss-ai/Apertus-70B", "a@epfl.ch"))
+
+
+def test_an_unreachable_serving_api_warns_but_does_not_block(monkeypatch, capsys):
+    """The gateway is the authority; this check is a courtesy. A launch must
+    not be blocked because the API was briefly unreachable."""
+    _patch_existing(monkeypatch, None, error=ServingApiError("network down"))
+    _run(warn_or_refuse_conflict("sk-rc-key", "alice/swiss-ai/Apertus-70B", "a@epfl.ch"))
+    assert "could not check for an authorization conflict" in capsys.readouterr().err
+
+
+def test_namespace_makes_cross_user_collisions_impossible():
+    """A sanity check on the interaction with namespacing: two users cannot
+    collide on a served name at all, so the conflict guard only ever fires on
+    one user relaunching their own name with a new policy."""
+    from swiss_ai_model_launch.launchers.served_name import namespace_served_model_name
+
+    alice = namespace_served_model_name("swiss-ai/Apertus-70B", "alice")
+    bob = namespace_served_model_name("swiss-ai/Apertus-70B", "bob")
+    assert alice != bob
+
+
+def test_loadtest_advanced_applies_the_policy_too(monkeypatch, tmp_path):
+    """`sml loadtest advanced` submits a real launch through the same advanced
+    arguments, so a policy passed there must reach the LaunchArgs rather than
+    being silently dropped."""
+    from swiss_ai_model_launch.cli import loadtest as loadtest_module
+
+    seen = {}
+
+    def fake_build(args, **kwargs):
+        seen.update(kwargs)
+        raise SystemExit("stop-after-build")
+
+    class _Config:
+        @classmethod
+        def exists(cls):
+            return True
+
+        @classmethod
+        def load(cls):
+            return cls()
+
+        def get_non_none_value(self, name):
+            return "sk-rc-key"
+
+        def get_value(self, name):
+            return None
+
+    async def fake_create_launcher(config, args, non_interactive=False):
+        class _L:
+            username = "alice"
+            account = "proj01"
+            partition = "normal"
+
+        return _L()
+
+    monkeypatch.setenv("SML_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(loadtest_module, "InitConfig", _Config)
+    args = _build_parser().parse_args(
+        [
+            "loadtest",
+            "advanced",
+            "--framework",
+            "sglang",
+            "--environment",
+            "/path/to/env.toml",
+            "--authorization",
+            "a@epfl.ch",
+        ]
+    )
+
+    with pytest.raises(SystemExit, match="stop-after-build"):
+        _run(
+            loadtest_module._run_loadtest_advanced(
+                args,
+                create_launcher=fake_create_launcher,
+                build_launch_args_from_advanced=fake_build,
+            )
+        )
+    assert seen["authorization"] == "a@epfl.ch"
+
+
+def test_argparse_namespace_without_the_flag_defaults_to_public():
+    """Callers that build a Namespace by hand (tests, example scripts) must
+    not accidentally launch with no policy at all."""
+    assert _run(resolve_authorization(requested_from_args(argparse.Namespace()), "sk-rc-key")) == "public"

--- a/tests/unit/test_authorization.py
+++ b/tests/unit/test_authorization.py
@@ -3,11 +3,13 @@ launch, the label it puts on the mesh, and the served-name conflict guard."""
 
 import argparse
 import asyncio
+import importlib
 
 import pytest
 
 from swiss_ai_model_launch.cli import authorization as cli_authorization
 from swiss_ai_model_launch.cli.authorization import (
+    is_valid_authorization,
     requested_from_args,
     resolve_authorization,
     warn_or_refuse_conflict,
@@ -64,6 +66,17 @@ def test_policy_ignores_order_case_and_spacing():
     assert policy_of("public") is None
     assert policy_of("") is None
     assert policy_of("a@x.ch") != policy_of("a@x.ch,b@y.ch")
+
+
+def test_is_valid_authorization_is_the_prompts_predicate():
+    """The interactive prompt needs a bool, not an exception — a bad answer
+    must re-prompt rather than crash the wizard."""
+    assert is_valid_authorization("public")
+    assert is_valid_authorization("private")
+    assert is_valid_authorization("a@epfl.ch,b@ethz.ch")
+    assert not is_valid_authorization("not-an-email")
+    assert not is_valid_authorization("")
+    assert not is_valid_authorization("public,a@epfl.ch")
 
 
 def test_predicates_and_description():
@@ -274,6 +287,61 @@ def test_namespace_makes_cross_user_collisions_impossible():
     alice = namespace_served_model_name("swiss-ai/Apertus-70B", "alice")
     bob = namespace_served_model_name("swiss-ai/Apertus-70B", "bob")
     assert alice != bob
+
+
+def test_run_advanced_labels_the_launch_with_the_resolved_policy(monkeypatch):
+    """End to end through the real `sml advanced` path: the flag is resolved,
+    reaches the launch, and is what the conflict check is asked about."""
+    # `swiss_ai_model_launch.cli.main` also names the CLI entry-point
+    # *function* re-exported from the package, so a plain import binds that
+    # instead of the module. Monkeypatching needs the module object.
+    main_module = importlib.import_module("swiss_ai_model_launch.cli.main")
+
+    # Parse before stubbing InitConfig: _build_parser() consults the real one.
+    args = _advanced_args("--authorization", "private")
+    seen = {}
+
+    class _Config:
+        @classmethod
+        def exists(cls):
+            return True
+
+        @classmethod
+        def load(cls):
+            return cls()
+
+        def get_non_none_value(self, name):
+            return "sk-rc-key"
+
+    class _Launcher:
+        username = "alice"
+        account = "proj01"
+        partition = "normal"
+        reservation = None
+
+    async def fake_create_launcher(config, args, non_interactive=False):
+        return _Launcher()
+
+    async def fake_conflict_check(api_key, served_model_name, authorization):
+        seen["served"] = served_model_name
+        seen["authorization"] = authorization
+        raise SystemExit("stop-before-submit")
+
+    async def fake_whoami(api_key):
+        return "Alice@EPFL.ch"
+
+    monkeypatch.setattr(main_module, "InitConfig", _Config)
+    monkeypatch.setattr(main_module, "_create_launcher", fake_create_launcher)
+    monkeypatch.setattr(main_module, "warn_or_refuse_conflict", fake_conflict_check)
+    monkeypatch.setattr(cli_authorization, "whoami", fake_whoami)
+
+    with pytest.raises(SystemExit, match="stop-before-submit"):
+        _run(main_module._run_advanced(args))
+
+    # 'private' became the launcher's own email, and the name it guards is the
+    # namespaced one the job will actually advertise.
+    assert seen["authorization"] == "alice@epfl.ch"
+    assert seen["served"] == "alice/swiss-ai/Apertus-70B"
 
 
 def test_loadtest_advanced_applies_the_policy_too(monkeypatch, tmp_path):

--- a/tests/unit/test_authorization.py
+++ b/tests/unit/test_authorization.py
@@ -409,3 +409,41 @@ def test_argparse_namespace_without_the_flag_defaults_to_public():
     """Callers that build a Namespace by hand (tests, example scripts) must
     not accidentally launch with no policy at all."""
     assert _run(resolve_authorization(requested_from_args(argparse.Namespace()), "sk-rc-key")) == "public"
+
+
+# ── launch provenance ───────────────────────────────────────────────────────
+
+
+def test_labels_record_the_sml_version():
+    """Which SML built a launch is the first question when one misbehaves —
+    the label carries it onto the mesh alongside the policy."""
+    import importlib.metadata
+
+    from swiss_ai_model_launch.launchers.framework import _sml_version
+
+    labels = _opentela_labels(_launch_args())
+    assert f"--label sml_version={_sml_version()}" in labels
+    assert _sml_version() == importlib.metadata.version("swiss-ai-model-launch")
+
+
+def test_sml_version_is_baked_in_not_resolved_on_the_node():
+    """SML isn't installed on the compute node, so a $(...) here would render
+    an empty label. The value must be a literal in the script."""
+    labels = _opentela_labels(_launch_args())
+    version_line = next(line for line in labels.splitlines() if "sml_version=" in line)
+    assert "$" not in version_line and "`" not in version_line
+
+
+def test_sml_version_falls_back_when_the_package_is_not_installed(monkeypatch):
+    """Running from an uninstalled source checkout must not fail the launch
+    over a provenance label."""
+    import importlib.metadata
+
+    from swiss_ai_model_launch.launchers import framework as framework_module
+
+    def missing(_name):
+        raise importlib.metadata.PackageNotFoundError(_name)
+
+    monkeypatch.setattr(framework_module.importlib.metadata, "version", missing)
+    assert framework_module._sml_version() == "unknown"
+    assert "--label sml_version=unknown" in framework_module._opentela_labels(_launch_args())

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -21,6 +21,13 @@ from swiss_ai_model_launch.launchers.framework import render_master, render_rank
 _HAS_SHELLCHECK = shutil.which("shellcheck") is not None
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
+# The examples namespace their served name as "$USER/<vendor>/<model>". A real
+# invocation goes through a shell, which expands $USER before sml sees it;
+# shlex.split does not, so the parse helper below expands it to this name and
+# the tests build LaunchArgs under the same one. Without that, the literal
+# "$USER" would read as somebody else's namespace and be rejected.
+_TEST_USERNAME = "alice"
+
 
 def _parse_sml_advanced_script(content: str):
     """Extract the `sml advanced` flags from an example shell script.
@@ -30,6 +37,7 @@ def _parse_sml_advanced_script(content: str):
     argparse Namespace.
     """
     text = content
+    text = text.replace("${USER}", _TEST_USERNAME).replace("$USER", _TEST_USERNAME)
     text = re.sub(r"\\\n", " ", text)  # collapse line continuations
     text = re.sub(r"^\s*#.*$", "", text, flags=re.MULTILINE)  # strip comments
     tokens = shlex.split(text)
@@ -65,7 +73,7 @@ def test_example_renders_valid_bash(tmp_path: Path, example_path: str):
     args = _parse_sml_advanced_script(full_path.read_text())
     launch_args = build_launch_args_from_advanced(
         args,
-        username="alice",
+        username=_TEST_USERNAME,
         account="proj01-test",
         partition="normal",
     )
@@ -93,7 +101,7 @@ def test_example_passes_shellcheck(tmp_path: Path, example_path: str):
     args = _parse_sml_advanced_script(full_path.read_text())
     launch_args = build_launch_args_from_advanced(
         args,
-        username="alice",
+        username=_TEST_USERNAME,
         account="proj01-test",
         partition="normal",
     )

--- a/tests/unit/test_idempotent_submit.py
+++ b/tests/unit/test_idempotent_submit.py
@@ -102,7 +102,7 @@ def test_named_launch_adopts_the_job_a_failed_submit_created() -> None:
     job_id, served = asyncio.run(launcher.launch_model(_request(job_name="evalsvc-abc123")))
 
     assert job_id == 4242
-    assert served == "alice/swiss-ai/Apertus-8B-Instruct-2509"
+    assert served == "alice/swiss-ai/Apertus-8B-Instruct-2509-sglang"
     assert client.submits == 1  # no second sbatch
     assert len(client.lookups) == 1
 

--- a/tests/unit/test_served_name.py
+++ b/tests/unit/test_served_name.py
@@ -2,6 +2,7 @@ import pytest
 
 from swiss_ai_model_launch.cli.main import _build_parser, build_launch_args_from_advanced
 from swiss_ai_model_launch.launchers.served_name import (
+    derive_served_model_name,
     is_namespaced,
     namespace_of,
     namespace_served_model_name,
@@ -84,3 +85,40 @@ def test_advanced_rejects_someone_elses_namespace():
     args = _advanced_args("--served-model-name bob/swiss-ai/Apertus-70B")
     with pytest.raises(ValueError, match="namespaced under 'bob'"):
         build_launch_args_from_advanced(args, username="alice", account="proj01", partition="normal")
+
+
+def test_derived_name_carries_the_framework():
+    """Without this, one user's sglang and vllm deployments of a model land on
+    the mesh under a single id and OpenTela balances across two different
+    engines — the salt used to hide that, and the salt is gone."""
+    sglang = derive_served_model_name("swiss-ai/Apertus-8B", "sglang", "alice")
+    vllm = derive_served_model_name("swiss-ai/Apertus-8B", "vllm", "alice")
+
+    assert sglang == "alice/swiss-ai/Apertus-8B-sglang"
+    assert vllm == "alice/swiss-ai/Apertus-8B-vllm"
+    assert sglang != vllm
+
+
+def test_derived_name_is_still_three_segments():
+    """The gateway only lists ids with exactly three non-empty segments, so the
+    framework has to be a suffix, not another path segment."""
+    assert derive_served_model_name("swiss-ai/Apertus-8B", "vllm", "alice").count("/") == 2
+
+
+def test_same_user_same_framework_still_shares_a_name():
+    """Deliberate: two launches of one model on one framework are replicas, and
+    OpenTela load-balancing across them is the point."""
+    first = derive_served_model_name("swiss-ai/Apertus-8B", "sglang", "alice")
+    second = derive_served_model_name("swiss-ai/Apertus-8B", "sglang", "alice")
+    assert first == second
+
+
+def test_derived_name_requires_a_framework():
+    with pytest.raises(ValueError, match="without a framework"):
+        derive_served_model_name("swiss-ai/Apertus-8B", "  ", "alice")
+
+
+def test_explicit_names_are_never_framework_suffixed():
+    """Only derived names get the suffix; a name the user chose is theirs —
+    even when that means two frameworks share it, which is the user's call."""
+    assert namespace_served_model_name("alice/swiss-ai/Apertus-8B", "alice") == "alice/swiss-ai/Apertus-8B"

--- a/tests/unit/test_serving_api.py
+++ b/tests/unit/test_serving_api.py
@@ -1,0 +1,178 @@
+"""The Serving API client used at launch time: identity lookup for
+`--authorization private`, and the pre-launch served-name policy check.
+
+Both calls decide who can reach a model, so every failure mode has to be a
+loud ServingApiError — never a silent empty answer that a caller might read
+as "no restriction".
+"""
+
+import asyncio
+
+import httpx
+import pytest
+
+from swiss_ai_model_launch import serving_api
+from swiss_ai_model_launch.serving_api import (
+    BASE_URL,
+    ServingApiError,
+    served_model_authorizations,
+    whoami,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _FakeClient:
+    """Stands in for httpx.AsyncClient: records the request and replays a
+    caller-supplied response (or raises the given exception)."""
+
+    def __init__(self, handler, calls):
+        self._handler = handler
+        self._calls = calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def get(self, url, headers=None, timeout=None):
+        self._calls.append({"url": url, "headers": headers or {}, "timeout": timeout})
+        return self._handler()
+
+
+def _patch_http(monkeypatch, handler):
+    """Returns the list the fake client appends each request to."""
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        serving_api.httpx,
+        "AsyncClient",
+        lambda *a, **k: _FakeClient(handler, calls),
+    )
+    return calls
+
+
+def _responds(status, payload=None):
+    def handler():
+        return httpx.Response(status, json=payload if payload is not None else {})
+
+    return handler
+
+
+def _raises(exc):
+    def handler():
+        raise exc
+
+    return handler
+
+
+# ── whoami ──────────────────────────────────────────────────────────────────
+
+
+def test_whoami_returns_the_email_and_sends_the_bearer(monkeypatch):
+    calls = _patch_http(monkeypatch, _responds(200, {"email": "alice@epfl.ch"}))
+
+    assert _run(whoami("sk-rc-key")) == "alice@epfl.ch"
+    assert calls[0]["url"] == f"{BASE_URL}/v1/whoami"
+    assert calls[0]["headers"]["Authorization"] == "Bearer sk-rc-key"
+
+
+def test_whoami_401_names_the_key_as_the_problem(monkeypatch):
+    """The most likely cause is an unconfigured or rotated key, so say so
+    rather than surfacing a bare status code."""
+    _patch_http(monkeypatch, _responds(401))
+
+    with pytest.raises(ServingApiError, match="rejected your Swiss AI Research API key"):
+        _run(whoami("sk-rc-stale"))
+
+
+def test_whoami_other_http_error_is_reported(monkeypatch):
+    _patch_http(monkeypatch, _responds(503))
+
+    with pytest.raises(ServingApiError, match="HTTP 503"):
+        _run(whoami("sk-rc-key"))
+
+
+def test_whoami_network_failure_is_reported(monkeypatch):
+    _patch_http(monkeypatch, _raises(httpx.ConnectError("no route")))
+
+    with pytest.raises(ServingApiError, match="Could not reach the Serving API"):
+        _run(whoami("sk-rc-key"))
+
+
+def test_whoami_timeout_is_reported(monkeypatch):
+    _patch_http(monkeypatch, _raises(httpx.ReadTimeout("slow")))
+
+    with pytest.raises(ServingApiError, match="Could not reach the Serving API"):
+        _run(whoami("sk-rc-key"))
+
+
+def test_whoami_without_an_email_is_an_error_not_an_empty_string(monkeypatch):
+    """An empty email would normalize into an invalid label and quietly
+    restrict the model to nobody."""
+    _patch_http(monkeypatch, _responds(200, {}))
+
+    with pytest.raises(ServingApiError, match="no email address"):
+        _run(whoami("sk-rc-key"))
+
+
+# ── served_model_authorizations ─────────────────────────────────────────────
+
+
+_MODELS = {
+    "data": [
+        {"id": "alice/org/m", "labels": {"authorization": "a@epfl.ch"}},
+        {"id": "alice/org/m", "labels": {"authorization": "a@epfl.ch"}},
+        {"id": "alice/org/other", "labels": {"authorization": "public"}},
+        {"id": "bob/org/m", "labels": {"authorization": "b@ethz.ch"}},
+    ]
+}
+
+
+def test_authorizations_returns_only_the_matching_names_labels(monkeypatch):
+    calls = _patch_http(monkeypatch, _responds(200, _MODELS))
+
+    assert _run(served_model_authorizations("sk-rc-key", "alice/org/m")) == [
+        "a@epfl.ch",
+        "a@epfl.ch",
+    ]
+    assert calls[0]["url"] == f"{BASE_URL}/v1/models_detailed"
+    assert calls[0]["headers"]["Authorization"] == "Bearer sk-rc-key"
+
+
+def test_authorizations_is_empty_when_the_name_is_not_served(monkeypatch):
+    _patch_http(monkeypatch, _responds(200, _MODELS))
+
+    assert _run(served_model_authorizations("sk-rc-key", "alice/org/unlaunched")) == []
+
+
+def test_authorizations_reads_a_missing_label_as_empty(monkeypatch):
+    """A peer with no authorization label is public; the caller compares
+    normalized policies, so "" has to survive the trip."""
+    _patch_http(monkeypatch, _responds(200, {"data": [{"id": "alice/org/m"}]}))
+
+    assert _run(served_model_authorizations("sk-rc-key", "alice/org/m")) == [""]
+
+
+def test_authorizations_tolerates_an_empty_payload(monkeypatch):
+    _patch_http(monkeypatch, _responds(200, {}))
+
+    assert _run(served_model_authorizations("sk-rc-key", "alice/org/m")) == []
+
+
+def test_authorizations_http_error_is_reported(monkeypatch):
+    _patch_http(monkeypatch, _responds(500))
+
+    with pytest.raises(ServingApiError, match="HTTP 500"):
+        _run(served_model_authorizations("sk-rc-key", "alice/org/m"))
+
+
+def test_authorizations_network_failure_is_reported(monkeypatch):
+    """The caller downgrades this to a warning — it must be distinguishable
+    from "no conflicting peers", which is why it raises rather than returns []."""
+    _patch_http(monkeypatch, _raises(httpx.ConnectError("no route")))
+
+    with pytest.raises(ServingApiError, match="Could not reach the Serving API"):
+        _run(served_model_authorizations("sk-rc-key", "alice/org/m"))


### PR DESCRIPTION
Companion to serving-api's label-based model authorization ([ADR-0001](https://github.com/swiss-ai/serving-api/blob/main/docs/adrs/0001-label-based-model-authorization.md)). A launch now declares who the model is for, as an OpenTela peer label the gateway enforces:

    sml ... --authorization public                        # anyone (default)
    sml ... --authorization private                       # only the launcher
    sml ... --authorization user1@epfl.ch,user2@ethz.ch   # only these users

"private" never reaches the mesh — the gateway cannot know who submitted a job, so the CLI resolves it to the launcher's own email via the Serving API's GET /v1/whoami before submission, and fails the launch rather than falling back to public if that call can't be made. LaunchArgs rejects an unresolved "private" as a guardrail for any path that forgets.

Values are canonicalized (strip, lowercase, dedupe) so two launches meaning the same policy emit the same label, and a served name whose replicas disagree on policy is refused by the gateway for everyone — so a launch that would collide with a running model under a different policy is refused up front instead of taking that model down with it.

Applied on every path that submits a launch: `preconfigured`, `advanced`, both `loadtest` launch paths, and the MCP server's launch tool.

## Launch identity: `launch_id` and `launched_by_email`

A peer label is immutable for the life of the SLURM job, so `--authorization` can only ever set the policy a model *starts* with. serving-api [ADR-0002](https://github.com/swiss-ai/serving-api/blob/main/docs/adrs/0002-post-launch-access-overrides.md) adds a **Manage access** menu that changes a running model's audience without relaunching, and **Reset** to put it back. That needs two facts from the launch that the mesh did not previously carry:

- **`launched_by_email`** — the launcher's platform identity, resolved via `/v1/whoami`. The existing `launched_by` label is `$USER`, a **cluster shell account** (`bdoan`, `dmelikidze`), which cannot be compared against a Serving API key's `owner_email`. Without this label the gateway genuinely cannot tell which platform user launched a model, so it cannot tell whose model it is to manage.
- **`launch_id`** — a UUID identifying *this* launch, generated per `LaunchArgs` so every path that builds one gets a fresh id for free. The gateway records a post-launch access change against this rather than against the served name, so a change can never outlive its job and re-apply to a different launch that later takes the same name.

`launched_by_email` resolution is deliberately **best-effort**, unlike the `private` resolution above. There the email *is* the access policy, so failing to resolve it has to fail the launch. Here it only decides who may edit the policy afterwards, and refusing to launch a public model because the Serving API was briefly unreachable would be the worse trade — so the launch proceeds with a warning, and the model is admin-managed. `whoami` is memoized per API key so a `private` launch still makes one call, not two.

## Other changes

- `sml_version` label, recording which SML rendered a launch — baked in as a literal on the submitting machine, since SML isn't installed on the compute node.
- Framework included in derived served-model names, and examples updated to write served-model names with their namespace.

## Docs

`docs/usage-advanced.md` (Model authorization), `docs/usage-sml.md`, and `docs/glossary.md` now describe both layers: the flag sets the launch-time policy, the web UI changes it afterwards, and a relaunch starts again at whatever the flag says.

## Testing

428 unit tests pass; `ruff` and `markdownlint` clean. New coverage for the launch-identity labels: uniqueness and per-render stability of `launch_id`, that `launched_by_email` defaults to empty rather than to a guess (an invented owner could then change the model's access), and that resolution failure warns without failing the launch.

## Merging plan

Coupled with https://github.com/swiss-ai/serving-api/pull/115, but not merged together — serving-api goes first (Stages 0–1), then this PR is tested against dev and merged (Stages 2–4). Until then the gateway simply sees no `launch_id` / `launched_by_email` labels and reports those models as admin-managed.
