### PR TITLE
Fix Docker Image Build in CI

### DIFF
--- a/.github/scripts/build_image.py
+++ b/.github/scripts/build_image.py
@@ -80,14 +80,77 @@ def _build_slurm_script(
         export XDG_RUNTIME_DIR="${{TMPDIR:-/tmp}}/podman-runtime-$$"
         mkdir -p "${{XDG_RUNTIME_DIR}}"
 
+        # Rootless podman ignores graphroot/runroot from /etc/containers/storage.conf
+        # and falls back to $HOME/.local/share/containers/storage. Home is NFS, which
+        # has no user xattrs, so even pulling the base image dies with
+        # "lsetxattr ...: operation not supported". Personal accounts have a
+        # ~/.config/containers/storage.conf pointing at tmpfs; the CI service account
+        # has none, so the job writes its own. tmpfs has no user xattrs either below
+        # kernel 6.6, hence fuse-overlayfs rather than the kernel overlay driver.
+        PODMAN_STORAGE="/dev/shm/${{USER}}/podman-${{SLURM_JOB_ID}}"
+        mkdir -p "${{PODMAN_STORAGE}}/root" "${{PODMAN_STORAGE}}/runroot"
+
+        FUSE_OVERLAYFS=""
+        for candidate in \
+            /usr/local/vs-ce-podman/fuse-overlayfs \
+            /usr/bin/fuse-overlayfs-1.13 \
+            "$(command -v fuse-overlayfs || true)"; do
+            if [ -x "${{candidate}}" ]; then
+                FUSE_OVERLAYFS="${{candidate}}"
+                break
+            fi
+        done
+        if [ -z "${{FUSE_OVERLAYFS}}" ]; then
+            echo "ERROR: no fuse-overlayfs on $(hostname); podman storage on tmpfs needs it"
+            exit 1
+        fi
+
+        # Kept outside PODMAN_STORAGE: the cleanup below still needs a valid
+        # config to tear that directory down.
+        export CONTAINERS_STORAGE_CONF="${{XDG_RUNTIME_DIR}}/storage.conf"
+        cat > "${{CONTAINERS_STORAGE_CONF}}" <<EOF
+        [storage]
+        driver = "overlay"
+        graphroot = "${{PODMAN_STORAGE}}/root"
+        runroot = "${{PODMAN_STORAGE}}/runroot"
+
+        [storage.options.overlay]
+        mount_program = "${{FUSE_OVERLAYFS}}"
+        EOF
+
+        # Seed the same config in this account's home, the way personal accounts
+        # have it, so podman run outside this script (interactive debugging, a
+        # future script that forgets the env var) also lands on tmpfs. The
+        # per-job CONTAINERS_STORAGE_CONF above still wins for this build: two
+        # builds can share a node, and a fixed home-level graphroot would have
+        # them trampling each other's layers and cleanup.
+        HOME_STORAGE_CONF="${{HOME}}/.config/containers/storage.conf"
+        if [ ! -e "${{HOME_STORAGE_CONF}}" ]; then
+            mkdir -p "$(dirname "${{HOME_STORAGE_CONF}}")"
+            cat > "${{HOME_STORAGE_CONF}}" <<EOF
+        [storage]
+        driver = "overlay"
+        graphroot = "/dev/shm/${{USER}}/root"
+        runroot = "/dev/shm/${{USER}}/runroot"
+
+        [storage.options.overlay]
+        mount_program = "${{FUSE_OVERLAYFS}}"
+        EOF
+            echo "Seeded ${{HOME_STORAGE_CONF}}"
+        fi
+
         IMAGE_TAG="{image_name}-{arch}-{channel}:${{SLURM_JOB_ID}}"
         SCRATCH_SQSH="${{SCRATCH}}/{image_name}-{arch}-{channel}.sqsh"
 
         cleanup() {{
             podman logout ghcr.io 2>/dev/null || true
-            podman rmi "${{IMAGE_TAG}}" 2>/dev/null || true
+            # Storage is job-scoped, so a full reset is safe and is the only
+            # thing that reliably empties it: layers are owned by mapped subuids
+            # and sit behind fuse mounts, so a plain rm hits "Permission denied"
+            # / "Device or resource busy". Left behind they occupy the node's RAM.
+            podman system reset --force 2>/dev/null || true
             rm -f "${{SCRATCH_SQSH}}" 2>/dev/null || true
-            rm -rf "${{XDG_RUNTIME_DIR}}" 2>/dev/null || true
+            rm -rf "${{PODMAN_STORAGE}}" "${{XDG_RUNTIME_DIR}}" 2>/dev/null || true
         }}
         trap cleanup EXIT
 

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -64,6 +64,20 @@ podman build --format docker -t my_image:dev .
 enroot import -o "$SCRATCH/my_image.sqsh" "podman://my_image:dev"
 ```
 
+This needs `~/.config/containers/storage.conf` pointing podman's storage at tmpfs — without it, rootless podman stores layers under `$HOME/.local/share/containers` on NFS and the first pulled layer fails with `lsetxattr ...: operation not supported`:
+
+```toml
+[storage]
+driver = "overlay"
+graphroot = "/dev/shm/<your-username>/root"
+runroot = "/dev/shm/<your-username>/runroot"
+
+[storage.options.overlay]
+mount_program = "/usr/bin/fuse-overlayfs-1.13"
+```
+
+`/dev/shm` is the node's RAM, so clear it out (`podman system reset`) when a build tree is no longer needed. CI does the equivalent per job — see [CI/CD](ci-cd.md#stage-3-image-builds).
+
 Then point an env toml at `$SCRATCH/my_image.sqsh`. A laptop `docker build` catches syntax and dependency errors but won't reproduce the CUDA/NCCL/libfabric environment or the arm64 path.
 
 ## Updating an image

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -77,6 +77,8 @@ Each arch builds natively on its own cluster via a different FireCREST endpoint:
 
 On the cluster: `podman build --format docker` → push `:<channel>-<arch>` → `enroot import` to squashfs → copy to capstor via `.tmp` + atomic `mv`. An `EXIT` trap cleans up the local image, scratch sqsh, and podman runtime dir.
 
+**Podman storage.** The job writes its own `storage.conf` (`CONTAINERS_STORAGE_CONF`) putting graphroot and runroot on node-local tmpfs under `/dev/shm/$USER/podman-$SLURM_JOB_ID`, with `mount_program` set to fuse-overlayfs. Rootless podman ignores the graphroot in `/etc/containers/storage.conf` and defaults to `$HOME/.local/share/containers/storage`; home is NFS, which has no user xattrs, so the build dies on the first pulled layer with `lsetxattr ...: operation not supported`. Personal accounts have this in `~/.config/containers/storage.conf`, the service account does not — so the job can't rely on it. Cleanup is `podman system reset --force`: layers are owned by mapped subuids behind fuse mounts, and a plain `rm -rf` leaves them in the node's RAM.
+
 **Caching.** Each leg has a sentinel keyed on channel, image, arch, and `hashFiles('images/<image>/**')`; a hit skips the build entirely. The channel is in the key because a PR build only proves the `pr-<N>` artifacts exist — otherwise merging an already-built PR would hit the cache and never publish `:latest`.
 
 ## Stage 4: secret scan


### PR DESCRIPTION
Cherry-picked from the `sglang_apertus` branch so the CI fix can land on `main` independently.

The image-build SLURM job was failing on the first pulled layer with `lsetxattr ...: operation not supported`. Rootless podman ignores the graphroot in `/etc/containers/storage.conf` and falls back to `$HOME/.local/share/containers/storage`; home is NFS, which has no user xattrs. Personal accounts have a `~/.config/containers/storage.conf` pointing at tmpfs, but the CI service account does not.

## Changes

- `.github/scripts/build_image.py`
  - The job now writes its own `storage.conf` (via `CONTAINERS_STORAGE_CONF`) putting graphroot/runroot on node-local tmpfs at `/dev/shm/$USER/podman-$SLURM_JOB_ID`, with `mount_program` set to fuse-overlayfs (tmpfs has no user xattrs below kernel 6.6 either, so the kernel overlay driver won't do).
  - fuse-overlayfs is located from a list of known paths, failing loudly if none is executable.
  - Seeds `~/.config/containers/storage.conf` for the service account if absent, so interactive `podman run` outside this script also lands on tmpfs. The per-job config still wins for the build itself, so two concurrent builds on one node don't trample each other's layers.
  - Cleanup switched from `podman rmi` to `podman system reset --force`: layers are owned by mapped subuids behind fuse mounts, so a plain `rm -rf` leaves them occupying the node's RAM.
- `docs/building-images.md` — documents the `storage.conf` prerequisite for building images by hand.
- `docs/ci-cd.md` — documents the podman storage setup under stage 3.