### PR TITLE
Add Qwen/Qwen3.5-27B (vllm)

### DIFF
--- a/examples/clariden/cli/qwen/Qwen3.5-27B-vllm.sh
+++ b/examples/clariden/cli/qwen/Qwen3.5-27B-vllm.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+sml advanced \
+  --system clariden \
+  --partition normal \
+  --framework vllm \
+  --environment src/swiss_ai_model_launch/assets/envs/vllm.toml \
+  --framework-args "--model /capstor/store/cscs/swissai/infra01/hf_models/models/Qwen/Qwen3.5-27B \
+    --host 0.0.0.0 \
+    --served-model-name Qwen/Qwen3.5-27B \
+    --data-parallel-size 2 \
+    --tensor-parallel-size 2 \
+    --max-model-len 65536 \
+    --reasoning-parser qwen3"

--- a/src/swiss_ai_model_launch/assets/models.json
+++ b/src/swiss_ai_model_launch/assets/models.json
@@ -176,6 +176,13 @@
     "pre_launch_cmds": "pip install librosa audioread"
   },
   {
+    "model": "Qwen/Qwen3.5-27B",
+    "framework": "vllm",
+    "environment": null,
+    "nodes_per_replica": 1,
+    "framework_args": "--data-parallel-size 2 --tensor-parallel-size 2 --max-model-len 65536 --reasoning-parser qwen3"
+  },
+  {
     "model": "Qwen/Qwen3.6-27B",
     "framework": "vllm",
     "environment": null,


### PR DESCRIPTION
Adds `Qwen/Qwen3.5-27B` to the SML catalog and a Clariden example.

Mirrors the existing `Qwen/Qwen3.6-27B` entry (same `Qwen3_5ForConditionalGeneration` architecture): vllm, single node, DP2×TP2, 64k context, `--reasoning-parser qwen3`.

**Verified on Clariden.** Launched via `sml advanced`; the vLLM server came up (vLLM supports the arch natively, no `--trust-remote-code`), `/v1/models` and `/v1/chat/completions` returned 200, and greedy decoding produced a correct answer.

Model is present at `/capstor/store/cscs/swissai/infra01/hf_models/models/Qwen/Qwen3.5-27B`.

Checklist:
- [x] Model downloaded to `/capstor/store/cscs/swissai/infra01/hf_models/models/`
- [x] Tested launching with `sml advanced`