### PR TITLE
list_dir: only 404/403 mean the path is unreachable; let other FirecREST errors propagate

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -157,4 +157,5 @@ CI authenticates as a **service account**, not a personal account: the key is se
 | Build "succeeded", image unchanged | Sentinel cache hit — nothing under `images/<name>/` changed |
 | Merge skipped after a green build | The other arch failed, or a scan failed |
 | `path does not exist or is not readable` | A catalog entry's or recipe's weights moved or were deleted — repoint it or drop it |
+| `UnexpectedStatusException: last request: 408 …` / `500 …` in a path test | FirecREST couldn't list the directory (command timeout, backend error) even after retries — the path itself is fine; re-run the job |
 | `no model path extracted from: …` | An example's model flag isn't in a shape the extractor reads — see `tests/example_paths.py` |

--- a/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
+++ b/src/swiss_ai_model_launch/launchers/firecrest_launcher.py
@@ -19,9 +19,14 @@ from swiss_ai_model_launch.launchers.utils import (
     call_with_firecrest_retry,
     create_salt,
     decode_log,
+    firecrest_status,
     render_sbatch_header,
     resolve_model_path,
 )
+
+# FirecREST's ls answers: 404 for "No such file or directory", 403 for
+# "Permission denied". Only these mean the path itself is unreachable.
+_PATH_UNREACHABLE_STATUSES = frozenset({403, 404})
 
 _SGLANG_ENVIRONMENT = files("swiss_ai_model_launch.assets.envs").joinpath("sglang.toml")
 _VLLM_ENVIRONMENT = files("swiss_ai_model_launch.assets.envs").joinpath("vllm.toml")
@@ -235,8 +240,15 @@ class FirecRESTLauncher(Launcher):
                     dereference=True,
                 )
             )
-        except (FileNotFoundError, f7t.FirecrestException):
-            return None
+        except f7t.UnexpectedStatusException as exc:
+            # FirecREST turns ls's "No such file or directory" into 404 and
+            # "Permission denied" into 403 — both are verdicts on the path.
+            # Anything else (408 command timeout, 5xx that outlived the
+            # retries, ...) says nothing about the path, so it propagates
+            # rather than masquerading as a missing directory.
+            if firecrest_status(exc) in _PATH_UNREACHABLE_STATUSES:
+                return None
+            raise
         return [str(item["name"]) for item in listing]
 
     async def get_preconfigured_models(self) -> list[ModelCatalogEntry]:

--- a/src/swiss_ai_model_launch/launchers/utils.py
+++ b/src/swiss_ai_model_launch/launchers/utils.py
@@ -26,14 +26,21 @@ _FIRECREST_RETRY_DELAYS_SEC: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0, 16.0)
 _RETRYABLE_STATUSES = frozenset({408, 429})
 
 
+def firecrest_status(exc: BaseException) -> int | None:
+    """HTTP status of the FirecREST response behind ``exc``, if it carries one."""
+    if not isinstance(exc, f7t.UnexpectedStatusException):
+        return None
+    try:
+        return int(exc.responses[-1].status_code)
+    except (AttributeError, IndexError, TypeError, ValueError):
+        return None
+
+
 def is_firecrest_retryable(exc: BaseException) -> bool:
     """Whether a failed FirecREST call may be retried (transient error)."""
-    if isinstance(exc, f7t.UnexpectedStatusException):
-        try:
-            status = exc.responses[-1].status_code
-        except (AttributeError, IndexError):
-            return False
-        return status in _RETRYABLE_STATUSES or bool(500 <= status < 600)
+    status = firecrest_status(exc)
+    if status is not None:
+        return status in _RETRYABLE_STATUSES or 500 <= status < 600
     return isinstance(exc, httpx.HTTPError)
 
 

--- a/tests/unit/test_idempotent_submit.py
+++ b/tests/unit/test_idempotent_submit.py
@@ -13,7 +13,7 @@ import pytest
 from firecrest import UnexpectedStatusException
 
 from swiss_ai_model_launch.launchers import FirecRESTLauncher, JobStatus, LaunchRequest
-from swiss_ai_model_launch.launchers.utils import is_firecrest_retryable
+from swiss_ai_model_launch.launchers.utils import firecrest_status, is_firecrest_retryable
 
 
 def _status_error(code: int) -> UnexpectedStatusException:
@@ -82,6 +82,13 @@ def test_408_and_429_count_as_transient() -> None:
     assert is_firecrest_retryable(_status_error(503))
     assert not is_firecrest_retryable(_status_error(400))
     assert not is_firecrest_retryable(ValueError("nope"))
+
+
+def test_firecrest_status_reads_the_last_response() -> None:
+    assert firecrest_status(_status_error(404)) == 404
+    # Not a FirecREST status error at all, or one that carries no response.
+    assert firecrest_status(httpx.ConnectError("down")) is None
+    assert firecrest_status(UnexpectedStatusException([], 200)) is None
 
 
 def test_named_launch_adopts_the_job_a_failed_submit_created() -> None:

--- a/tests/unit/test_list_dir.py
+++ b/tests/unit/test_list_dir.py
@@ -1,7 +1,9 @@
+import asyncio
 from pathlib import Path
 from typing import Any, cast
 
 import firecrest as f7t
+import httpx
 import pytest
 
 from swiss_ai_model_launch.launchers.firecrest_launcher import FirecRESTLauncher
@@ -9,22 +11,34 @@ from swiss_ai_model_launch.launchers.model_catalog_entry import ModelCatalogEntr
 from swiss_ai_model_launch.launchers.slurm_launcher import SlurmLauncher
 
 
-class FakeFirecrestClient:
-    """Serves ``ls`` from a dict; unknown paths fail the way FirecREST does."""
+def _unexpected_status(status: int) -> f7t.UnexpectedStatusException:
+    """What pyfirecrest raises when FirecREST answers ``ls`` with ``status``."""
+    request = httpx.Request("GET", "https://firecrest.test/filesystem/test-system/ops/ls")
+    response = httpx.Response(status, json={"message": f"status {status}"}, request=request)
+    return f7t.UnexpectedStatusException([response], 200)  # type: ignore[no-untyped-call]
 
-    def __init__(self, listings: dict[str, list[str]]) -> None:
+
+class FakeFirecrestClient:
+    """Serves ``ls`` from a dict; other paths fail with the given status (404 like FirecREST, by default)."""
+
+    def __init__(self, listings: dict[str, list[str]], failure_status: int = 404) -> None:
         self.listings = listings
+        self.failure_status = failure_status
         self.dereferenced: list[bool] = []
+        self.calls = 0
 
     async def list_files(self, system_name: str, path: str, dereference: bool = False, **kwargs: object) -> list[dict]:
+        self.calls += 1
         self.dereferenced.append(dereference)
         if path not in self.listings:
-            raise f7t.FirecrestException([])
+            raise _unexpected_status(self.failure_status)
         return [{"name": name, "type": "-"} for name in self.listings[path]]
 
 
-def _firecrest_launcher(listings: dict[str, list[str]]) -> tuple[FirecRESTLauncher, FakeFirecrestClient]:
-    client = FakeFirecrestClient(listings)
+def _firecrest_launcher(
+    listings: dict[str, list[str]], failure_status: int = 404
+) -> tuple[FirecRESTLauncher, FakeFirecrestClient]:
+    client = FakeFirecrestClient(listings, failure_status)
     launcher = FirecRESTLauncher(
         cast(Any, client),
         "test-system",
@@ -43,10 +57,39 @@ async def test_firecrest_list_dir_returns_names() -> None:
     assert client.dereferenced == [True]
 
 
-async def test_firecrest_list_dir_returns_none_for_unreachable_path() -> None:
-    launcher, _ = _firecrest_launcher({})
+# FirecREST maps ls's "No such file or directory" to 404 and "Permission
+# denied" to 403; both are verdicts on the path.
+@pytest.mark.parametrize("status", [404, 403])  # type: ignore[misc]
+async def test_firecrest_list_dir_returns_none_for_unreachable_path(status: int) -> None:
+    launcher, _ = _firecrest_launcher({}, failure_status=status)
 
     assert await launcher.list_dir("/models/vendor/gone") is None
+
+
+async def test_firecrest_list_dir_propagates_transient_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 5xx that outlives the retries is an error, not a missing directory.
+
+    Reporting it as "missing" is how CI flagged perfectly good checkpoints
+    as stale whenever FirecREST hiccupped.
+    """
+
+    async def instant(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", instant)
+    launcher, client = _firecrest_launcher({}, failure_status=500)
+
+    with pytest.raises(f7t.UnexpectedStatusException):
+        await launcher.list_dir("/models/vendor/model")
+    assert client.calls > 1  # it was retried before giving up
+
+
+async def test_firecrest_list_dir_propagates_other_client_errors() -> None:
+    launcher, client = _firecrest_launcher({}, failure_status=400)
+
+    with pytest.raises(f7t.UnexpectedStatusException):
+        await launcher.list_dir("/models/vendor/model")
+    assert client.calls == 1  # 4xx isn't retried
 
 
 async def test_slurm_list_dir_reads_the_local_filesystem(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Since #210, `test_example_path_is_valid` has failed on a *different* path in every CI run — Mixtral-8x22B on main, Qwen3.5-397B / Qwen3.6-27B / Ministral-3 / `Alignment/trials/…` on one #211 run, the Apertus-v1p5 tokenizer and `rleval/…_1606_480it` on the next. All of those directories exist on Clariden with `config.json` and the same ACLs as their passing siblings.

`FirecRESTLauncher.list_dir` catches every `FirecrestException` and returns `None`, which `check_path` reports as `path does not exist or is not readable`. pyfirecrest raises `UnexpectedStatusException` for any non-200, so a 408 (FirecREST's `ls` command timeout) or a 5xx that outlived `call_with_firecrest_retry`'s five attempts was indistinguishable from a deleted checkpoint — and with `pytest.fail(..., pytrace=False)` the real status never reached the log.

## Fix

FirecREST 2.5.6 maps `ls`'s `No such file or directory` to **404** and `Permission denied` to **403** ([`base_command_error_handling.py`](https://github.com/eth-cscs/firecrest-v2/blob/2.5.6/src/firecrest/filesystem/ops/commands/base_command_error_handling.py)); `timeout` exit 124 becomes **408**, everything else **500**.

- `list_dir` now returns `None` only for 403/404 — verdicts on the path — and re-raises anything else, so the test fails with the actual `UnexpectedStatusException: last request: 408 …` instead of a bogus "missing".
- `utils.firecrest_status()` extracts the status once; `_is_firecrest_retryable` reuses it.
- Unit tests: 404 and 403 → `None`; 500 propagates after retries; 400 propagates without retrying.
- `docs/ci-cd.md`: a row for the new symptom.

No behaviour change for genuinely missing/unreadable paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)