### PR TITLE
tests: serialise keyring writes across xdist workers

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,11 @@
+import fcntl
 import os
 import tempfile
 from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
+import keyring
 import pytest
 
 _REQUIRED_ENV_VARS_FOR_SML_CONFIG = [
@@ -39,6 +42,33 @@ from swiss_ai_model_launch.launchers.firecrest_launcher import FirecRESTLauncher
 from tests.integration.utils import firecrest_auth_env  # noqa: E402
 
 
+@contextmanager
+def _keyring_write_lock() -> Iterator[None]:
+    """Serialise secret writes across xdist workers sharing one file-backed keyring.
+
+    Every worker runs the session fixture below, and on CI the keyring is
+    keyrings.alt's plaintext file under ~/.local/share/python_keyring. Its
+    backend creates that directory with a bare ``os.makedirs`` — two workers
+    racing for it on a fresh runner leave one with ``FileExistsError``, which
+    then fails every test on that worker — and its read-modify-write of the
+    file isn't atomic either. Create the directory up front and hold a lock
+    while writing. Keyrings without a ``file_path`` (macOS Keychain, ...) take
+    care of themselves.
+    """
+    file_path = getattr(keyring.get_keyring(), "file_path", None)
+    if not file_path:
+        yield
+        return
+    storage_root = Path(file_path).parent
+    storage_root.mkdir(parents=True, exist_ok=True)
+    with (storage_root / ".sml-tests.lock").open("w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock, fcntl.LOCK_UN)
+
+
 @pytest.fixture(scope="session", autouse=True)  # type: ignore[misc]
 def sml_config_dir() -> Iterator[Path]:
     """Write a throwaway InitConfig into _BOOTSTRAP_DIR so `sml advanced` can run without `sml init`."""
@@ -47,13 +77,14 @@ def sml_config_dir() -> Iterator[Path]:
         return
 
     config = InitConfig()
-    config.set_value("launcher", "firecrest")
-    config.set_value("firecrest_url", os.environ["SML_FIRECREST_URL"])
-    if _HAS_CLIENT_CREDENTIALS:
-        for env_var in _CLIENT_CREDENTIALS_ENV_VARS:
-            config.set_value(env_var.removeprefix("SML_").lower(), os.environ[env_var])
-    config.set_value("swissai_research_api_key", os.environ["SML_SWISSAI_RESEARCH_API_KEY"])
-    config.save()
+    with _keyring_write_lock():
+        config.set_value("launcher", "firecrest")
+        config.set_value("firecrest_url", os.environ["SML_FIRECREST_URL"])
+        if _HAS_CLIENT_CREDENTIALS:
+            for env_var in _CLIENT_CREDENTIALS_ENV_VARS:
+                config.set_value(env_var.removeprefix("SML_").lower(), os.environ[env_var])
+        config.set_value("swissai_research_api_key", os.environ["SML_SWISSAI_RESEARCH_API_KEY"])
+        config.save()
 
     yield _BOOTSTRAP_DIR
 


### PR DESCRIPTION
## Problem

Main's post-merge run [33120371812](https://github.com/swiss-ai/model-launch/actions/runs/33120371812) (rerun) died in 23 s with **12 passed, 90 errors**, every one:

```
FileExistsError: [Errno 17] File exists: '/home/runner/.local/share/python_keyring'
  keyrings/alt/file_base.py:161 in _ensure_file_path -> os.makedirs(storage_root)
  <- keyring.set_password  <- InitConfig.set_value  <- conftest sml_config_dir (session, autouse)
```

`sml_config_dir` runs on each of the `-n 2` xdist workers and writes secrets into the keyring; on CI that's `keyrings.alt`'s plaintext file backend, whose `_ensure_file_path` calls `os.makedirs` without `exist_ok`. On a fresh runner both workers race for the directory; the loser raises, the session fixture error is cached, and every test on that worker errors. The backend's read-modify-write of `keyring_pass.cfg` isn't atomic either.

## Fix

`_keyring_write_lock()` in `tests/integration/conftest.py`: if the active keyring exposes a `file_path`, create its directory with `exist_ok=True` and hold an `fcntl.flock` for the duration of the config writes. Backends without a file path (macOS Keychain locally) are untouched.

Verified locally with `PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring` and four concurrent processes on a fresh `XDG_DATA_HOME`: all writes land, file stays `0600`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)